### PR TITLE
Add `Close()` to SerialClient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,12 @@
 module github.com/aldas/go-modbus-client
 
-go 1.16
+go 1.17
 
 require github.com/stretchr/testify v1.7.0
+
+require (
+	github.com/davecgh/go-spew v1.1.0 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/objx v0.1.0 // indirect
+	gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c // indirect
+)

--- a/serialclient.go
+++ b/serialclient.go
@@ -154,6 +154,17 @@ func (c *SerialClient) do(ctx context.Context, data []byte, expectedLen int) ([]
 	return result, nil
 }
 
+// Close closes serial connection to the device
+func (c *SerialClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.serialPort == nil {
+		return nil
+	}
+	return c.serialPort.Close()
+}
+
 func (c *SerialClient) flush() error {
 	if !c.isFlusher {
 		return nil


### PR DESCRIPTION
so we can have interface
```go
type modbusClient interface {
	Do(ctx context.Context, req packet.Request) (packet.Response, error)
	Close() error
}
```