### PR TITLE
Add FC17 Read Server ID (0x11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+* Added support for FC17 (0x11) Read Server ID.
 * Added `packet.LooksLikeModbusTCP()` to check if given bytes are possibly TCP packet or start of packet.
 * Added `Parse*Request*` for every function type to help implement Modbus servers.
 * Added `Server` package to implement your own modbus server

--- a/Makefile
+++ b/Makefile
@@ -21,8 +21,8 @@ vet: ## Vet the files
 test: ## Run unittests
 	@go test -short ${PKG_LIST}
 
-goversion ?= "1.20"
-test_version: ## Run tests inside Docker with given version (defaults to 1.20). Example: make test_version goversion=1.20
+goversion ?= "1.21"
+test_version: ## Run tests inside Docker with given version (defaults to 1.21). Example: make test_version goversion=1.21
 	@docker run --rm -it -v $(shell pwd):/project golang:$(goversion) /bin/sh -c "cd /project && make init check"
 
 race: ## Run data race detector

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ go get github.com/aldas/go-modbus-client
 * FC6 - Write Single Register ([req](packet/writesingleregisterrequest.go)/[resp](packet/writesingleregisterresponse.go))
 * FC15 - Write Multiple Coils ([req](packet/writemultiplecoilsrequest.go)/[resp](packet/writemultiplecoilsresponse.go))
 * FC16 - Write Multiple Registers ([req](packet/writemultipleregistersrequest.go)/[resp](packet/writemultipleregistersresponse.go))
+* FC17 - Read Server ID ([req](packet/readserveridrequest.go)/[resp](packet/readserveridresponse.go))
 * FC23 - Read / Write Multiple Registers ([req](packet/readwritemultipleregistersrequest.go)/[resp](packet/readwritemultipleregistersresponse.go))
 
 ## Goals
@@ -118,6 +119,7 @@ req, err := packet.NewReadInputRegistersRequestTCP(0, 10, 9)
 req, err := packet.NewWriteSingleCoilRequestTCP(0, 10, true)
 req, err := packet.NewWriteSingleRegisterRequestTCP(0, 10, []byte{0xCA, 0xFE})
 req, err := packet.NewWriteMultipleCoilsRequestTCP(0, 10, []bool{true, false, true})
+req, err := packet.NewReadServerIDRequestTCP(0)
 req, err := packet.NewWriteMultipleRegistersRequestTCP(0, 10, []byte{0xCA, 0xFE, 0xBA, 0xBE})
 ```
 

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -30,11 +30,13 @@ const (
 	FunctionWriteMultipleCoils = uint8(15) // 0x0f
 	// FunctionWriteMultipleRegisters is function code for Write Multiple Registers (FC16)
 	FunctionWriteMultipleRegisters = uint8(16) // 0x10
+	// FunctionReadServerID is function code for Read Server ID (FC16)
+	FunctionReadServerID = uint8(17) // 0x11
 	// FunctionReadWriteMultipleRegisters is function code for Read / Write Multiple Registers (FC23)
 	FunctionReadWriteMultipleRegisters = uint8(23) // 0x17
 )
 
-var supportedFunctionCodes = [9]byte{
+var supportedFunctionCodes = [10]byte{
 	FunctionReadCoils,
 	FunctionReadDiscreteInputs,
 	FunctionReadHoldingRegisters,
@@ -43,6 +45,7 @@ var supportedFunctionCodes = [9]byte{
 	FunctionWriteSingleRegister,
 	FunctionWriteMultipleCoils,
 	FunctionWriteMultipleRegisters,
+	FunctionReadServerID,
 	FunctionReadWriteMultipleRegisters,
 }
 
@@ -105,12 +108,12 @@ func LooksLikeModbusTCP(data []byte, allowUnSupportedFunctionCodes bool) (expect
 	// Example of first 8 bytes
 	// 0x81 0x80 - transaction id (0,1)
 	// 0x00 0x00 - protocol id (2,3)
-	// 0x00 0x06 - number of bytes in the message (PDU = ProtocolDataUnit) to follow (4,5)
+	// 0x00 0x02 - number of bytes in the message (PDU = ProtocolDataUnit) to follow (4,5)
 	// 0x10 - unit id (6)
-	// 0x01 - function code (7)
+	// 0x11 - function code (7)
 
-	// minimal amount is 9 bytes (header + unit id + function code + 1 byte of something ala error code)
-	if len(data) < 9 {
+	// minimal amount is 8 bytes (header + unit id + function code)
+	if len(data) < 8 {
 		return 0, ErrTCPDataTooShort
 	}
 	if !(data[2] == 0x0 && data[3] == 0x0) { // check protocol id

--- a/packet/packet_test.go
+++ b/packet/packet_test.go
@@ -100,7 +100,7 @@ func TestLooksLikeModbusTCP(t *testing.T) {
 		},
 		{
 			name:         "nok, too few bytes",
-			when:         []byte{0x01, 0x02, 0x00, 0x00, 0x00, 0x06, 0x10, 0x01},
+			when:         []byte{0x01, 0x02, 0x00, 0x00, 0x00, 0x06, 0x10},
 			expectLength: 0,
 			expectError:  "data is too short to be a Modbus TCP packet",
 		},

--- a/packet/readserveridrequest.go
+++ b/packet/readserveridrequest.go
@@ -1,0 +1,145 @@
+package packet
+
+import (
+	"math/rand"
+)
+
+// ReadServerIDRequestTCP is TCP Request for Read Server ID function (FC=17, 0x11)
+//
+// Example packet:  0x81 0x80 0x00 0x00 0x00 0x02 0x10 0x11
+// 0x81 0x80 - transaction id (0,1)
+// 0x00 0x00 - protocol id (2,3)
+// 0x00 0x02 - number of bytes in the message (PDU = ProtocolDataUnit) to follow (4,5)
+// 0x10 - unit id (6)
+// 0x11 - function code (7)
+type ReadServerIDRequestTCP struct {
+	MBAPHeader
+	ReadServerIDRequest
+}
+
+// ReadServerIDRequestRTU is RTU Request for Read Server ID function (FC=17, 0x11)
+//
+// Example packet:  0x10 0x11 0xcc 0x7c
+// 0x10 - unit id (0)
+// 0x11 - function code (1)
+// 0xcc 0x7c - CRC16 (6,7)
+type ReadServerIDRequestRTU struct {
+	ReadServerIDRequest
+}
+
+// ReadServerIDRequest is Request for Read Server ID function (FC=17, 0x11)
+type ReadServerIDRequest struct {
+	UnitID uint8
+}
+
+// NewReadServerIDRequestTCP creates new instance of Read Server ID TCP request
+func NewReadServerIDRequestTCP(unitID uint8) (*ReadServerIDRequestTCP, error) {
+	return &ReadServerIDRequestTCP{
+		MBAPHeader: MBAPHeader{
+			TransactionID: uint16(1 + rand.Intn(65534)),
+			ProtocolID:    0,
+		},
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: unitID,
+		},
+	}, nil
+}
+
+// Bytes returns ReadServerIDRequestTCP packet as bytes form
+func (r ReadServerIDRequestTCP) Bytes() []byte {
+	length := uint16(2)
+	result := make([]byte, tcpMBAPHeaderLen+length)
+	r.MBAPHeader.bytes(result[0:6], length)
+	r.ReadServerIDRequest.bytes(result[6 : 6+length])
+	return result
+}
+
+// ExpectedResponseLength returns length of bytes that valid response to this request would be
+func (r ReadServerIDRequestTCP) ExpectedResponseLength() int {
+	// response = 6 header len + 1 unitID + 1 fc
+	return 6 + 2
+}
+
+// ParseReadServerIDRequestTCP parses given bytes into ReadServerIDRequestTCP
+func ParseReadServerIDRequestTCP(data []byte) (*ReadServerIDRequestTCP, error) {
+	header, err := ParseMBAPHeader(data)
+	if err != nil {
+		return nil, err
+	}
+	unitID := data[6]
+	if data[7] != FunctionReadServerID {
+		tmpErr := NewErrorParseTCP(ErrIllegalFunction, "received function code in packet is not 0x11")
+		tmpErr.Packet.TransactionID = header.TransactionID
+		tmpErr.Packet.UnitID = unitID
+		tmpErr.Packet.Function = FunctionReadServerID
+		return nil, tmpErr
+	}
+	return &ReadServerIDRequestTCP{
+		MBAPHeader: header,
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: unitID,
+		},
+	}, nil
+}
+
+// NewReadServerIDRequestRTU creates new instance of Read Server ID RTU request
+func NewReadServerIDRequestRTU(unitID uint8) (*ReadServerIDRequestRTU, error) {
+	return &ReadServerIDRequestRTU{
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: unitID,
+		},
+	}, nil
+}
+
+// Bytes returns ReadServerIDRequestRTU packet as bytes form
+func (r ReadServerIDRequestRTU) Bytes() []byte {
+	result := make([]byte, 2+2)
+	bytes := r.ReadServerIDRequest.bytes(result)
+	crc := CRC16(bytes[:2])
+	result[2] = uint8(crc)
+	result[3] = uint8(crc >> 8)
+	return result
+}
+
+// ExpectedResponseLength returns length of bytes that valid response to this request would be
+func (r ReadServerIDRequestRTU) ExpectedResponseLength() int {
+	// response = 1 UnitID + 1 functionCode
+	return 2
+}
+
+// ParseReadServerIDRequestRTU parses given bytes into ReadServerIDRequestRTU
+// Does not check CRC
+func ParseReadServerIDRequestRTU(data []byte) (*ReadServerIDRequestRTU, error) {
+	dLen := len(data)
+	if dLen != 4 && dLen != 2 { // with or without CRC bytes
+		return nil, NewErrorParseRTU(ErrServerFailure, "invalid data length to be valid packet")
+	}
+	unitID := data[0]
+	if data[1] != FunctionReadServerID {
+		tmpErr := NewErrorParseRTU(ErrIllegalFunction, "received function code in packet is not 0x11")
+		tmpErr.Packet.UnitID = unitID
+		tmpErr.Packet.Function = FunctionReadServerID
+		return nil, tmpErr
+	}
+	return &ReadServerIDRequestRTU{
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: unitID,
+		},
+	}, nil
+}
+
+// FunctionCode returns function code of this request
+func (r ReadServerIDRequest) FunctionCode() uint8 {
+	return FunctionReadServerID
+}
+
+// Bytes returns ReadServerIDRequest packet as bytes form
+func (r ReadServerIDRequest) Bytes() []byte {
+	return r.bytes(make([]byte, 2))
+}
+
+func (r ReadServerIDRequest) bytes(bytes []byte) []byte {
+	bytes[0] = r.UnitID
+	bytes[1] = FunctionReadServerID
+	return bytes
+}

--- a/packet/readserveridrequest_test.go
+++ b/packet/readserveridrequest_test.go
@@ -1,0 +1,325 @@
+package packet
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewReadServerIDRequestTCP(t *testing.T) {
+	expect := ReadServerIDRequestTCP{
+		MBAPHeader: MBAPHeader{
+			TransactionID: 0x1234,
+			ProtocolID:    0,
+		},
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: 1,
+		},
+	}
+
+	var testCases = []struct {
+		name        string
+		whenUnitID  uint8
+		expect      *ReadServerIDRequestTCP
+		expectError string
+	}{
+		{
+			name:        "ok",
+			whenUnitID:  1,
+			expect:      &expect,
+			expectError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			packet, err := NewReadServerIDRequestTCP(tc.whenUnitID)
+
+			expect := tc.expect
+			if packet != nil {
+				assert.NotEqual(t, uint16(0), packet.TransactionID)
+				expect.TransactionID = packet.TransactionID
+			}
+			assert.Equal(t, expect, packet)
+
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadServerIDRequestTCP_Bytes(t *testing.T) {
+	example := ReadServerIDRequestTCP{
+		MBAPHeader: MBAPHeader{
+			TransactionID: 0x1234,
+			ProtocolID:    0,
+		},
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: 1,
+		},
+	}
+
+	var testCases = []struct {
+		name   string
+		given  func(r *ReadServerIDRequestTCP)
+		expect []byte
+	}{
+		{
+			name:   "ok",
+			given:  func(r *ReadServerIDRequestTCP) {},
+			expect: []byte{0x12, 0x34, 0x0, 0x0, 0x0, 0x2, 0x1, 0x11},
+		},
+		{
+			name: "ok2",
+			given: func(r *ReadServerIDRequestTCP) {
+				r.TransactionID = 1
+				r.UnitID = 16
+			},
+			expect: []byte{0x00, 0x01, 0x00, 0x00, 0x00, 0x02, 0x10, 0x11},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			given := example
+			tc.given(&given)
+
+			assert.Equal(t, tc.expect, given.Bytes())
+		})
+	}
+}
+
+func TestReadServerIDRequestTCP_ExpectedResponseLength(t *testing.T) {
+	example := ReadServerIDRequestTCP{
+		MBAPHeader: MBAPHeader{
+			TransactionID: 0x1234,
+			ProtocolID:    0,
+		},
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: 1,
+		},
+	}
+
+	assert.Equal(t, 8, example.ExpectedResponseLength())
+}
+
+func TestNewReadServerIDRequestRTU(t *testing.T) {
+	expect := ReadServerIDRequestRTU{
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: 1,
+		},
+	}
+
+	var testCases = []struct {
+		name        string
+		whenUnitID  uint8
+		expect      *ReadServerIDRequestRTU
+		expectError string
+	}{
+		{
+			name:        "ok",
+			whenUnitID:  1,
+			expect:      &expect,
+			expectError: "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			packet, err := NewReadServerIDRequestRTU(tc.whenUnitID)
+
+			assert.Equal(t, tc.expect, packet)
+
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadServerIDRequestRTU_Bytes(t *testing.T) {
+	example := ReadServerIDRequestRTU{
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: 1,
+		},
+	}
+
+	var testCases = []struct {
+		name   string
+		given  func(r *ReadServerIDRequestRTU)
+		expect []byte
+	}{
+		{
+			name:   "ok",
+			given:  func(r *ReadServerIDRequestRTU) {},
+			expect: []byte{0x1, 0x11, 0xc0, 0x2c},
+		},
+		{
+			name: "ok2",
+			given: func(r *ReadServerIDRequestRTU) {
+				r.UnitID = 16
+			},
+			expect: []byte{0x10, 0x11, 0xcc, 0x7c},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			given := example
+			tc.given(&given)
+
+			assert.Equal(t, tc.expect, given.Bytes())
+		})
+	}
+}
+
+func TestReadServerIDRequestRTU_ExpectedResponseLength(t *testing.T) {
+	example := ReadServerIDRequestRTU{
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: 1,
+		},
+	}
+
+	assert.Equal(t, 2, example.ExpectedResponseLength())
+}
+
+func TestReadServerIDRequest_FunctionCode(t *testing.T) {
+	given := ReadServerIDRequest{}
+	assert.Equal(t, uint8(17), given.FunctionCode())
+}
+
+func TestReadServerIDRequest_Bytes(t *testing.T) {
+	example := ReadServerIDRequest{
+		UnitID: 1,
+	}
+
+	var testCases = []struct {
+		name   string
+		given  func(r *ReadServerIDRequest)
+		expect []byte
+	}{
+		{
+			name:   "ok",
+			given:  func(r *ReadServerIDRequest) {},
+			expect: []byte{0x1, 0x11},
+		},
+		{
+			name: "ok2",
+			given: func(r *ReadServerIDRequest) {
+				r.UnitID = 16
+			},
+			expect: []byte{0x10, 0x11},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			given := example
+			tc.given(&given)
+
+			assert.Equal(t, tc.expect, given.Bytes())
+		})
+	}
+}
+
+func TestParseReadServerIDRequestTCP(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		when        []byte
+		expect      *ReadServerIDRequestTCP
+		expectError string
+	}{
+		{
+			name: "ok, parse ReadServerIDRequestTCP",
+			when: []byte{0x01, 0x02, 0x00, 0x00, 0x00, 0x02, 0x10, 0x11},
+			expect: &ReadServerIDRequestTCP{
+				MBAPHeader: MBAPHeader{
+					TransactionID: 0x0102,
+					ProtocolID:    0,
+				},
+				ReadServerIDRequest: ReadServerIDRequest{
+					UnitID: 0x10,
+				},
+			},
+		},
+		{
+			name:        "nok, invalid header",
+			when:        []byte{0x01, 0x02, 0x00, 0x00, 0x00, 0x03, 0x10, 0x11},
+			expect:      nil,
+			expectError: "packet length does not match length in header",
+		},
+		{
+			name:        "nok, invalid function code",
+			when:        []byte{0x01, 0x02, 0x00, 0x00, 0x00, 0x02, 0x10, 0x12},
+			expect:      nil,
+			expectError: "received function code in packet is not 0x11",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ParseReadServerIDRequestTCP(tc.when)
+
+			assert.Equal(t, tc.expect, result)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseReadServerIDRequestRTU(t *testing.T) {
+	example := ReadServerIDRequestRTU{
+		ReadServerIDRequest: ReadServerIDRequest{
+			UnitID: 0x10,
+		},
+	}
+	var testCases = []struct {
+		name        string
+		when        []byte
+		expect      *ReadServerIDRequestRTU
+		expectError string
+	}{
+		{
+			name:   "ok, parse ReadServerIDRequestRTU, with crc bytes",
+			when:   []byte{0x10, 0x11, 0xff, 0xff},
+			expect: &example,
+		},
+		{
+			name:   "ok, parse ReadServerIDRequestRTU, without crc bytes",
+			when:   []byte{0x10, 0x11},
+			expect: &example,
+		},
+		{
+			name:        "nok, invalid data length to be valid packet",
+			when:        []byte{0x10, 0x11, 0xff},
+			expect:      nil,
+			expectError: "invalid data length to be valid packet",
+		},
+		{
+			name:        "nok, invalid function code",
+			when:        []byte{0x10, 0x12, 0xff, 0xff},
+			expect:      nil,
+			expectError: "received function code in packet is not 0x11",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := ParseReadServerIDRequestRTU(tc.when)
+
+			assert.Equal(t, tc.expect, result)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/packet/readserveridresponse.go
+++ b/packet/readserveridresponse.go
@@ -1,0 +1,173 @@
+package packet
+
+import (
+	"encoding/binary"
+	"errors"
+)
+
+// ReadServerIDResponseTCP is TCP Response for Read Server ID (FC=17) 0x11
+//
+// Example packet: 0x81 0x80 0x00 0x00 0x00 0x08 0x10 0x11 0x02 0x01 0x02 0x00 0x01 0x02
+// 0x81 0x80 - transaction id  (0,1)
+// 0x00 0x00 - protocol id (2,3)
+// 0x00 0x08 - number of bytes in the message (PDU = ProtocolDataUnit) to follow (4,5)
+// 0x10 - unit id (6)
+// 0x11 - function code (7)
+// 0x02 - byte count for server id (8)
+// 0x01 0x02 - N bytes for server id (device specific, variable length) (9,10)
+// 0x00 - run status (11)
+// 0x01 0x02 - optional N bytes for additional data (device specific, variable length) (12,13)
+type ReadServerIDResponseTCP struct {
+	MBAPHeader
+	ReadServerIDResponse
+}
+
+// ReadServerIDResponseRTU is RTU Response for Read Server ID (FC=17) 0x11
+//
+// Example packet: 0x10 0x11 0x02 0x01 0x02 0x00 0x01 0x02 0xd5 0x43
+// 0x10 - unit id (0)
+// 0x11 - function code (1)
+// 0x02 - byte count for server id (2)
+// 0x01 0x02 - N bytes for server id (device specific, variable length) (3,4)
+// 0x00 - run status (5)
+// 0x01 0x02 - optional N bytes for additional data (device specific, variable length) (6,7)
+// 0xd5 0x43 - CRC16 (n-2,n-1)
+type ReadServerIDResponseRTU struct {
+	ReadServerIDResponse
+}
+
+// ReadServerIDResponse is Response for Read Server ID (FC=17) 0x11
+type ReadServerIDResponse struct {
+	UnitID         uint8
+	Status         uint8
+	ServerID       []byte
+	AdditionalData []byte
+}
+
+// Bytes returns ReadServerIDResponseTCP packet as bytes form
+func (r ReadServerIDResponseTCP) Bytes() []byte {
+	length := r.ReadServerIDResponse.len()
+	result := make([]byte, tcpMBAPHeaderLen+length)
+	r.MBAPHeader.bytes(result[0:6], length)
+	r.ReadServerIDResponse.bytes(result[6:])
+	return result
+}
+
+// ParseReadServerIDResponseTCP parses given bytes into ReadServerIDResponseTCP
+func ParseReadServerIDResponseTCP(data []byte) (*ReadServerIDResponseTCP, error) {
+	dLen := len(data)
+	if dLen < 11 {
+		return nil, errors.New("received data length too short to be valid packet")
+	}
+	serverIDLen := int(data[8])
+	if serverIDLen == 0 {
+		return nil, errors.New("server id length too small to be valid packet")
+	}
+	statusIdx := 8 + serverIDLen + 1
+	if statusIdx >= len(data) {
+		return nil, errors.New("received data length too short to be valid packet")
+	}
+	serverID := make([]byte, serverIDLen)
+	copy(serverID, data[9:9+serverIDLen])
+
+	status := data[statusIdx]
+
+	var additionalData []byte
+	if len(data) > statusIdx+1 {
+		additionalData = make([]byte, len(data)-statusIdx-1)
+		copy(additionalData, data[statusIdx+1:])
+	}
+
+	return &ReadServerIDResponseTCP{
+		MBAPHeader: MBAPHeader{
+			TransactionID: binary.BigEndian.Uint16(data[0:2]),
+			ProtocolID:    0,
+		},
+		ReadServerIDResponse: ReadServerIDResponse{
+			UnitID: data[6],
+			// fc (7)
+			// server id len (8)
+			ServerID:       serverID,
+			Status:         status,
+			AdditionalData: additionalData,
+		},
+	}, nil
+}
+
+// Bytes returns ReadServerIDResponseRTU packet as bytes form
+func (r ReadServerIDResponseRTU) Bytes() []byte {
+	length := r.len() + 2
+	result := make([]byte, length)
+	bytes := r.ReadServerIDResponse.bytes(result)
+	crc := CRC16(bytes[:length-2])
+	result[length-2] = uint8(crc)
+	result[length-1] = uint8(crc >> 8)
+	return result
+}
+
+// ParseReadServerIDResponseRTU parses given bytes into ReadServerIDResponseRTU
+func ParseReadServerIDResponseRTU(data []byte) (*ReadServerIDResponseRTU, error) {
+	dLen := len(data)
+	if dLen < 7 {
+		return nil, errors.New("received data length too short to be valid packet")
+	}
+	serverIDLen := int(data[2])
+	if serverIDLen == 0 {
+		return nil, errors.New("server id length too small to be valid packet")
+	}
+	statusIdx := 2 + serverIDLen + 1
+	if statusIdx >= len(data)-2 {
+		return nil, errors.New("received data length too short to be valid packet")
+	}
+	serverID := make([]byte, serverIDLen)
+	copy(serverID, data[3:3+serverIDLen])
+
+	status := data[statusIdx]
+
+	var additionalData []byte
+	if len(data) > statusIdx+1 {
+		additionalData = make([]byte, len(data)-2-statusIdx-1)
+		copy(additionalData, data[statusIdx+1:len(data)-2])
+	}
+	return &ReadServerIDResponseRTU{
+		ReadServerIDResponse: ReadServerIDResponse{
+			UnitID: data[0],
+			// fc (1)
+			// server id len (2)
+			ServerID:       serverID,
+			Status:         status,
+			AdditionalData: additionalData,
+		},
+	}, nil
+}
+
+// FunctionCode returns function code of this request
+func (r ReadServerIDResponse) FunctionCode() uint8 {
+	return FunctionReadServerID
+}
+
+func (r ReadServerIDResponse) len() uint16 {
+	// unit id (1) + fc (1) + server id len (1) + server id (N) + status (1) + additional data (N)
+	return 4 + uint16(len(r.ServerID)) + uint16(len(r.AdditionalData))
+}
+
+// Bytes returns ReadServerIDResponse packet as bytes form
+func (r ReadServerIDResponse) Bytes() []byte {
+	return r.bytes(make([]byte, r.len()))
+}
+
+func (r ReadServerIDResponse) bytes(data []byte) []byte {
+	data[0] = r.UnitID
+	data[1] = FunctionReadServerID
+
+	serverIDLen := uint8(len(r.ServerID))
+	data[2] = serverIDLen
+	copy(data[3:3+serverIDLen], r.ServerID)
+
+	data[3+serverIDLen] = r.Status
+	if r.AdditionalData != nil {
+		copy(data[4+serverIDLen:], r.AdditionalData)
+	}
+
+	return data
+}

--- a/packet/readserveridresponse_test.go
+++ b/packet/readserveridresponse_test.go
@@ -1,0 +1,261 @@
+package packet
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestReadServerIDResponseTCP_Bytes(t *testing.T) {
+	example := ReadServerIDResponseTCP{
+		MBAPHeader: MBAPHeader{
+			TransactionID: 0x1234,
+			ProtocolID:    0,
+		},
+		ReadServerIDResponse: ReadServerIDResponse{
+			UnitID:         1,
+			Status:         0xff,
+			ServerID:       []byte{0x01},
+			AdditionalData: []byte{0x03, 0x04},
+		},
+	}
+
+	var testCases = []struct {
+		name   string
+		given  func(r *ReadServerIDResponseTCP)
+		expect []byte
+	}{
+		{
+			name:   "ok",
+			given:  func(r *ReadServerIDResponseTCP) {},
+			expect: []byte{0x12, 0x34, 0x0, 0x0, 0x0, 0x7, 0x1, 0x11, 0x1, 0x01, 0xFF, 0x03, 0x04},
+		},
+		{
+			name: "ok2",
+			given: func(r *ReadServerIDResponseTCP) {
+				r.TransactionID = 1
+
+				r.UnitID = 16
+				r.Status = 0xFE
+				r.ServerID = []byte{0x10, 0x11}
+				r.AdditionalData = nil
+			},
+			expect: []byte{0x0, 0x1, 0x0, 0x0, 0x0, 0x6, 0x10, 0x11, 0x2, 0x10, 0x11, 0xfe},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			given := example
+			tc.given(&given)
+
+			assert.Equal(t, tc.expect, given.Bytes())
+		})
+	}
+}
+
+func TestParseReadServerIDResponseTCP(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		given       []byte
+		expect      *ReadServerIDResponseTCP
+		expectError string
+	}{
+		{
+			name:  "ok",
+			given: []byte{0x81, 0x80, 0x00, 0x00, 0x00, 0x08, 0x03, 0x11, 0x02, 0x01, 0x02, 0xFF, 0x03, 0x04},
+			expect: &ReadServerIDResponseTCP{
+				MBAPHeader: MBAPHeader{
+					TransactionID: 33152,
+					ProtocolID:    0,
+				},
+				ReadServerIDResponse: ReadServerIDResponse{
+					UnitID:         3,
+					Status:         0xff,
+					ServerID:       []byte{0x01, 0x02},
+					AdditionalData: []byte{0x03, 0x04},
+				},
+			},
+		},
+		{
+			name:  "ok, without additional data",
+			given: []byte{0x81, 0x80, 0x00, 0x00, 0x00, 0x08, 0x03, 0x11, 0x01, 0x01, 0xFF},
+			expect: &ReadServerIDResponseTCP{
+				MBAPHeader: MBAPHeader{
+					TransactionID: 33152,
+					ProtocolID:    0,
+				},
+				ReadServerIDResponse: ReadServerIDResponse{
+					UnitID:         3,
+					Status:         0xff,
+					ServerID:       []byte{0x01},
+					AdditionalData: nil,
+				},
+			},
+		},
+		{
+			name:        "nok, too short",
+			given:       []byte{0x81, 0x80, 0x00, 0x00, 0x00, 0x08, 0x03, 0x11, 0x00, 0x01},
+			expectError: "received data length too short to be valid packet",
+		},
+		{
+			name:        "nok, too small",
+			given:       []byte{0x81, 0x80, 0x00, 0x00, 0x00, 0x08, 0x03, 0x11, 0x00, 0x01, 0xFF},
+			expectError: "server id length too small to be valid packet",
+		},
+		{
+			name:        "nok, byte len does not match packet len",
+			given:       []byte{0x81, 0x80, 0x00, 0x00, 0x00, 0x08, 0x03, 0x11, 0x02, 0x01, 0xFF},
+			expectError: "received data length too short to be valid packet",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			packet, err := ParseReadServerIDResponseTCP(tc.given)
+
+			assert.Equal(t, tc.expect, packet)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestParseReadServerIDResponseRTU(t *testing.T) {
+	var testCases = []struct {
+		name        string
+		given       []byte
+		expect      *ReadServerIDResponseRTU
+		expectError string
+	}{
+		{
+			name:  "ok",
+			given: []byte{0x10, 0x11, 0x02, 0x01, 0x02, 0xff, 0x03, 0x04, 0xec, 0xd2},
+			expect: &ReadServerIDResponseRTU{
+				ReadServerIDResponse: ReadServerIDResponse{
+					UnitID:         16,
+					Status:         0xff,
+					ServerID:       []byte{0x01, 0x02},
+					AdditionalData: []byte{0x03, 0x04},
+				},
+			},
+		},
+		{
+			name:        "nok, too short",
+			given:       []byte{0x10, 0x11, 0x01, 0x01, 0xff, 0xCC},
+			expectError: "received data length too short to be valid packet",
+		},
+		{
+			name:        "nok, byte len does not match packet len",
+			given:       []byte{0x10, 0x11, 0x00, 0x01, 0xff, 0xCC, 0xCC},
+			expectError: "server id length too small to be valid packet",
+		},
+		{
+			name:        "nok, byte len does not match packet len",
+			given:       []byte{0x10, 0x11, 0x02, 0x01, 0xff, 0xCC, 0xCC},
+			expectError: "received data length too short to be valid packet",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			packet, err := ParseReadServerIDResponseRTU(tc.given)
+
+			assert.Equal(t, tc.expect, packet)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadServerIDResponseRTU_Bytes(t *testing.T) {
+	example := ReadServerIDResponseRTU{
+		ReadServerIDResponse: ReadServerIDResponse{
+			UnitID:         1,
+			Status:         0xff,
+			ServerID:       []byte{0x01, 0x02},
+			AdditionalData: []byte{0x03, 0x04},
+		},
+	}
+
+	var testCases = []struct {
+		name   string
+		given  func(r *ReadServerIDResponseRTU)
+		expect []byte
+	}{
+		{
+			name:   "ok",
+			given:  func(r *ReadServerIDResponseRTU) {},
+			expect: []byte{0x1, 0x11, 0x02, 0x01, 0x02, 0xff, 0x03, 0x04, 0x8c, 0x5f},
+		},
+		{
+			name: "ok2",
+			given: func(r *ReadServerIDResponseRTU) {
+				r.UnitID = 16
+				r.Status = 0xFE
+				r.ServerID = []byte{0x10, 0x11}
+				r.AdditionalData = nil
+			},
+			expect: []byte{0x10, 0x11, 0x2, 0x10, 0x11, 0xfe, 0x73, 0x25},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			given := example
+			tc.given(&given)
+
+			assert.Equal(t, tc.expect, given.Bytes())
+		})
+	}
+}
+
+func TestReadServerIDResponse_FunctionCode(t *testing.T) {
+	given := ReadServerIDResponse{}
+	assert.Equal(t, uint8(17), given.FunctionCode())
+}
+
+func TestReadServerIDResponse_Bytes(t *testing.T) {
+	example := ReadServerIDResponse{
+		UnitID:         1,
+		Status:         0xff,
+		ServerID:       []byte{0x01},
+		AdditionalData: []byte{0x03, 0x04},
+	}
+
+	var testCases = []struct {
+		name   string
+		given  func(r *ReadServerIDResponse)
+		expect []byte
+	}{
+		{
+			name:   "ok",
+			given:  func(r *ReadServerIDResponse) {},
+			expect: []byte{0x1, 0x11, 0x1, 0x1, 0xff, 0x3, 0x4},
+		},
+		{
+			name: "ok2",
+			given: func(r *ReadServerIDResponse) {
+				r.UnitID = 16
+				r.Status = 0xFE
+				r.ServerID = []byte{0x10, 0x11}
+				r.AdditionalData = nil
+			},
+			expect: []byte{0x10, 0x11, 0x2, 0x10, 0x11, 0xFE},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			given := example
+			tc.given(&given)
+
+			assert.Equal(t, tc.expect, given.Bytes())
+		})
+	}
+}

--- a/packet/readwritemultipleregistersresponse.go
+++ b/packet/readwritemultipleregistersresponse.go
@@ -83,7 +83,7 @@ func (r ReadWriteMultipleRegistersResponseRTU) Bytes() []byte {
 	return result
 }
 
-// ParseReadWriteMultipleRegistersResponseRTU parses given bytes into ReadWriteMultipleRegistersResponseTCP
+// ParseReadWriteMultipleRegistersResponseRTU parses given bytes into ReadWriteMultipleRegistersResponseRTU
 func ParseReadWriteMultipleRegistersResponseRTU(data []byte) (*ReadWriteMultipleRegistersResponseRTU, error) {
 	dLen := len(data)
 	if dLen < 7 {

--- a/packet/request.go
+++ b/packet/request.go
@@ -18,7 +18,7 @@ type Request interface {
 
 // ParseTCPRequest parses given bytes into modbus TCP request packet or returns error
 func ParseTCPRequest(data []byte) (Request, error) {
-	if len(data) < 9 {
+	if len(data) < 8 {
 		return nil, ErrTCPDataTooShort
 	}
 	functionCode := data[7]
@@ -39,6 +39,8 @@ func ParseTCPRequest(data []byte) (Request, error) {
 		return ParseWriteMultipleCoilsRequestTCP(data)
 	case FunctionWriteMultipleRegisters: // 0x10
 		return ParseWriteMultipleRegistersRequestTCP(data)
+	case FunctionReadServerID: // 0x11
+		return ParseReadServerIDRequestTCP(data)
 	case FunctionReadWriteMultipleRegisters: // 0x17
 		return ParseReadWriteMultipleRegistersRequestTCP(data)
 	default:
@@ -49,7 +51,7 @@ func ParseTCPRequest(data []byte) (Request, error) {
 // ParseRTURequestWithCRC checks packet CRC and parses given bytes into modbus RTU request packet or returns error
 func ParseRTURequestWithCRC(data []byte) (Response, error) {
 	dataLen := len(data)
-	if dataLen < 5 {
+	if dataLen < 4 {
 		return nil, errors.New("data is too short to be a Modbus RTU packet")
 	}
 	packetCRC := binary.LittleEndian.Uint16(data[dataLen-2:])
@@ -63,7 +65,7 @@ func ParseRTURequestWithCRC(data []byte) (Response, error) {
 // ParseRTURequest parses given bytes into modbus RTU request packet or returns error
 // Does not check CRC.
 func ParseRTURequest(data []byte) (Request, error) {
-	if len(data) < 5 {
+	if len(data) < 4 {
 		return nil, errors.New("data is too short to be a Modbus RTU packet")
 	}
 	functionCode := data[1]
@@ -84,6 +86,8 @@ func ParseRTURequest(data []byte) (Request, error) {
 		return ParseWriteMultipleCoilsRequestRTU(data)
 	case FunctionWriteMultipleRegisters: // 0x10
 		return ParseWriteMultipleRegistersRequestRTU(data)
+	case FunctionReadServerID: // 0x11
+		return ParseReadServerIDRequestRTU(data)
 	case FunctionReadWriteMultipleRegisters: // 0x17
 		return ParseReadWriteMultipleRegistersRequestRTU(data)
 	default:

--- a/packet/request_test.go
+++ b/packet/request_test.go
@@ -172,8 +172,21 @@ func TestParseTCPRequest(t *testing.T) {
 			},
 		},
 		{
+			name: "ok, FunctionReadServerID",
+			when: []byte{0x12, 0x34, 0x0, 0x0, 0x0, 0x2, 0x1, 0x11},
+			expect: &ReadServerIDRequestTCP{
+				MBAPHeader: MBAPHeader{
+					TransactionID: 0x1234,
+					ProtocolID:    0,
+				},
+				ReadServerIDRequest: ReadServerIDRequest{
+					UnitID: 0x1,
+				},
+			},
+		},
+		{
 			name:        "nok, too short",
-			when:        []byte{0x01, 0x02, 0x00, 0x00, 0x00, 0x06, 0x10, 0x01},
+			when:        []byte{0x01, 0x02, 0x00, 0x00, 0x00, 0x06, 0x10},
 			expect:      nil,
 			expectError: "data is too short to be a Modbus TCP packet",
 		},
@@ -311,8 +324,17 @@ func TestParseRTURequestWithCRC(t *testing.T) {
 			},
 		},
 		{
+			name: "ok, parse ReadServerIDRequestRTU with crc",
+			when: []byte{0x10, 0x11, 0xcc, 0x7c},
+			expect: &ReadServerIDRequestRTU{
+				ReadServerIDRequest: ReadServerIDRequest{
+					UnitID: 0x10,
+				},
+			},
+		},
+		{
 			name:        "nok, too short",
-			when:        []byte{0x10, 0x01, 0x00, 0x6B},
+			when:        []byte{0x10, 0x00, 0x6B},
 			expect:      nil,
 			expectError: "data is too short to be a Modbus RTU packet",
 		},
@@ -364,7 +386,7 @@ func TestParseRTURequest(t *testing.T) {
 		},
 		{
 			name:        "nok, too short",
-			when:        []byte{0x10, 0x01, 0x00, 0x6B},
+			when:        []byte{0x10, 0x01, 0x00},
 			expect:      nil,
 			expectError: "data is too short to be a Modbus RTU packet",
 		},

--- a/packet/response.go
+++ b/packet/response.go
@@ -16,7 +16,7 @@ type Response interface {
 
 // ParseTCPResponse parses given bytes into modbus TCP response packet or into ErrorResponseTCP or returns error
 func ParseTCPResponse(data []byte) (Response, error) {
-	if len(data) < 9 {
+	if len(data) < 8 {
 		return nil, errors.New("data is too short to be a Modbus TCP packet")
 	}
 	if err := AsTCPErrorPacket(data); err != nil {
@@ -43,6 +43,8 @@ func ParseTCPResponse(data []byte) (Response, error) {
 		return ParseWriteMultipleRegistersResponseTCP(data)
 	case FunctionReadWriteMultipleRegisters: // 0x17
 		return ParseReadWriteMultipleRegistersResponseTCP(data)
+	case FunctionReadServerID: // 0x11
+		return ParseReadServerIDResponseTCP(data)
 	default:
 		return nil, fmt.Errorf("unknown function code parsed: %v", functionCode)
 	}
@@ -51,7 +53,7 @@ func ParseTCPResponse(data []byte) (Response, error) {
 // ParseRTUResponseWithCRC checks packet CRC and parses given bytes into modbus RTU response packet or into ErrorResponseRTU or returns error
 func ParseRTUResponseWithCRC(data []byte) (Response, error) {
 	dataLen := len(data)
-	if dataLen < 5 {
+	if dataLen < 4 {
 		return nil, errors.New("data is too short to be a Modbus RTU packet")
 	}
 	packetCRC := binary.LittleEndian.Uint16(data[dataLen-2:])
@@ -64,7 +66,7 @@ func ParseRTUResponseWithCRC(data []byte) (Response, error) {
 
 // ParseRTUResponse parses given bytes into modbus RTU response packet or into ErrorResponseRTU or returns error
 func ParseRTUResponse(data []byte) (Response, error) {
-	if len(data) < 5 {
+	if len(data) < 4 {
 		return nil, errors.New("data is too short to be a Modbus RTU packet")
 	}
 	if err := AsRTUErrorPacket(data); err != nil {
@@ -91,6 +93,8 @@ func ParseRTUResponse(data []byte) (Response, error) {
 		return ParseWriteMultipleRegistersResponseRTU(data)
 	case FunctionReadWriteMultipleRegisters: // 0x17
 		return ParseReadWriteMultipleRegistersResponseRTU(data)
+	case FunctionReadServerID: // 0x11
+		return ParseReadServerIDResponseRTU(data)
 	default:
 		return nil, fmt.Errorf("unknown function code parsed: %v", functionCode)
 	}

--- a/packet/response_test.go
+++ b/packet/response_test.go
@@ -155,6 +155,22 @@ func TestParseTCPResponse(t *testing.T) {
 			},
 		},
 		{
+			name:     "ok, ReadServerIDResponseTCP (fc17)",
+			whenData: []byte{0x81, 0x80, 0x00, 0x00, 0x00, 0x08, 0x03, 0x11, 0x02, 0x01, 0x02, 0xFF, 0x03, 0x04},
+			expect: &ReadServerIDResponseTCP{
+				MBAPHeader: MBAPHeader{
+					TransactionID: 33152,
+					ProtocolID:    0,
+				},
+				ReadServerIDResponse: ReadServerIDResponse{
+					UnitID:         3,
+					Status:         0xff,
+					ServerID:       []byte{0x01, 0x02},
+					AdditionalData: []byte{0x03, 0x04},
+				},
+			},
+		},
+		{
 			name:        "ok, ErrorResponseTCP (code=3)",
 			whenData:    []byte{0x4, 0xdd, 0x0, 0x0, 0x0, 0x3, 0x1, 0x82, 0x3},
 			expect:      nil,
@@ -162,7 +178,7 @@ func TestParseTCPResponse(t *testing.T) {
 		},
 		{
 			name:        "nok, data too short",
-			whenData:    []byte{0x12, 0x34, 0x0, 0x0, 0x0, 0x5, 0x1, 0x6},
+			whenData:    []byte{0x12, 0x34, 0x0, 0x0, 0x0, 0x5, 0x1},
 			expect:      nil,
 			expectError: "data is too short to be a Modbus TCP packet",
 		},
@@ -296,6 +312,18 @@ func TestParseRTUResponse(t *testing.T) {
 			},
 		},
 		{
+			name:     "ok, ReadServerIDResponseRTU (fc17)",
+			whenData: []byte{0x10, 0x11, 0x02, 0x01, 0x02, 0xff, 0x03, 0x04, 0xec, 0xd2},
+			expect: &ReadServerIDResponseRTU{
+				ReadServerIDResponse: ReadServerIDResponse{
+					UnitID:         16,
+					Status:         0xff,
+					ServerID:       []byte{0x01, 0x02},
+					AdditionalData: []byte{0x03, 0x04},
+				},
+			},
+		},
+		{
 			name:        "ok, ErrorResponseRTU (code=3)",
 			whenData:    []byte{0x1, 0x82, 0x3, 0xa1, 0x0},
 			expect:      nil,
@@ -303,7 +331,7 @@ func TestParseRTUResponse(t *testing.T) {
 		},
 		{
 			name:        "nok, data too short",
-			whenData:    []byte{0x1, 0x82, 0x3, 0xa1},
+			whenData:    []byte{0x1, 0x82, 0x3},
 			expect:      nil,
 			expectError: "data is too short to be a Modbus RTU packet",
 		},
@@ -355,7 +383,7 @@ func TestParseRTUResponseWithCRC(t *testing.T) {
 		},
 		{
 			name:        "nok, packet too short",
-			whenData:    []byte{0x1, 0x82, 0x3, 0xa1},
+			whenData:    []byte{0x1, 0x82, 0x3},
 			expect:      nil,
 			expectError: "data is too short to be a Modbus RTU packet",
 		},


### PR DESCRIPTION
This PR adds FC17 (0x11) Read Server ID, Requested by https://github.com/aldas/modbus-tcp-client/issues/55#issuecomment-1878040622

```
// ReadServerIDRequestRTU is RTU Request for Read Server ID function (FC=17, 0x11)
//
// Example packet:  0x10 0x11 0xcc 0x7c
// 0x10 - unit id (0)
// 0x11 - function code (1)
// 0xcc 0x7c - CRC16 (6,7)
```

```
// ReadServerIDResponseRTU is RTU Response for Read Server ID (FC=17) 0x11
//
// Example packet: 0x10 0x11 0x02 0x01 0x02 0x00 0x01 0x02 0xd5 0x43
// 0x10 - unit id (0)
// 0x11 - function code (1)
// 0x02 - byte count for server id (2)
// 0x01 0x02 - N bytes for server id (device specific, variable length) (3,4)
// 0x00 - run status (5)
// 0x01 0x02 - optional N bytes for additional data (device specific, variable length) (6,7)
// 0xd5 0x43 - CRC16 (n-2,n-1)
```