### PR TITLE
Builder can handle FC1/FC2 request batching

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,14 +14,14 @@ permissions:
 
 env:
   # run coverage only with the latest Go version
-  LATEST_GO_VERSION: "1.22"
+  LATEST_GO_VERSION: "1.23"
 
 
 jobs:
   test:
     strategy:
       matrix:
-        go-version: [ "1.21", "1.22" ]
+        go-version: [ "1.22", "1.23" ]
         platform: [ ubuntu-latest ]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,25 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres
 to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.0.2] - unreleased
+## [0.3.0] - unreleased
+
+Breaking changes to following structs/methods/functions
+
+* struct field `modbus.Field.RegisterAddress` was renamed to `Address`
+* struct `modbus.RegisterRequest` was renamed to `BuilderRequest`
+* method `BuilderRequest.ExtractFields()` signature changed
+
+### Added
+
+* Added FC1/FC2 support to builder. You can register coils with `b.Coild(address)` to be requested and extracted.
+  Builder has now following methods for splitting:
+    * `ReadCoilsTCP` combines fields into TCP Read Coils (FC1) requests
+    * `ReadCoilsRTU` combines fields into RTU Read Coils (FC1) requests
+    * `ReadDiscreteInputsTCP` combines fields into TCP Read Discrete Inputs (FC2) requests
+    * `ReadDiscreteInputsRTU` combines fields into RTU Read Discrete Inputs (FC2) requests
+
+
+## [0.2.0] - unreleased
 
 ### Added
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,10 @@ check: lint vet race ## check project
 init:
 	git config core.hooksPath ./scripts/.githooks
 	@go install golang.org/x/lint/golint@latest
+	@go install honnef.co/go/tools/cmd/staticcheck@latest
 
 lint: ## Lint the files
+	@staticcheck ${PKG_LIST}
 	@golint -set_exit_status ${PKG_LIST}
 
 vet: ## Vet the files
@@ -21,8 +23,8 @@ vet: ## Vet the files
 test: ## Run unittests
 	@go test -short ${PKG_LIST}
 
-goversion ?= "1.21"
-test_version: ## Run tests inside Docker with given version (defaults to 1.21). Example: make test_version goversion=1.21
+goversion ?= "1.23"
+test_version: ## Run tests inside Docker with given version (defaults to 1.23). Example: make test_version goversion=1.23
 	@docker run --rm -it -v $(shell pwd):/project golang:$(goversion) /bin/sh -c "cd /project && make init check"
 
 race: ## Run data race detector

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ for _, req := range requests {
     fmt.Printf("int64 @ address 18: %v", alarmDo1)
     
     // or extract values to FieldValue struct
-    fields, _ := req.ExtractFields(resp.(modbus.RegistersResponse), true)
+    fields, _ := req.ExtractFields(resp, true)
     assert.Equal(t, uint16(1), fields[0].Value)
     assert.Equal(t, "alarm_do_1", fields[1].Field.Name)
 }

--- a/builder.go
+++ b/builder.go
@@ -34,7 +34,10 @@ const (
 	// FieldTypeString represents N registers as string value. Use `Field.Length` to length of string.
 	FieldTypeString FieldType = 13
 
-	maxFieldTypeValue = uint8(13)
+	// FieldTypeCoil represents single discrete/coil value (used by FC1/FC2).
+	FieldTypeCoil FieldType = 14
+
+	maxFieldTypeValue = uint8(14)
 )
 
 // FieldType is enum type for data types that Field can represent
@@ -46,17 +49,19 @@ type Fields []Field
 // Field is distinct field be requested and extracted from response
 // Tag `mapstructure` allows you to marshal https://github.com/spf13/viper supported configuration format to the Field
 type Field struct {
+	Name string `json:"Name" mapstructure:"Name"`
+
 	ServerAddress string `json:"server_address" mapstructure:"server_address"` // [network://]host:port
 	UnitID        uint8  `json:"unit_id" mapstructure:"unit_id"`
+	// Address of the register (first register of that data type) or discrete/coil address in modbus. Addresses are 0-based.
+	Address uint16    `json:"address" mapstructure:"address"`
+	Type    FieldType `json:"type" mapstructure:"type"`
 
-	RegisterAddress uint16    `json:"register_address" mapstructure:"register_address"`
-	Type            FieldType `json:"type" mapstructure:"type"`
-	Bit             uint8     `json:"bit" mapstructure:"bit"`
-	FromHighByte    bool      `json:"from_high_byte" mapstructure:"from_high_byte"`
-	Length          uint8     `json:"Length" mapstructure:"Length"`
-
-	ByteOrder packet.ByteOrder `json:"byte_order" mapstructure:"byte_order"`
-	Name      string           `json:"Name" mapstructure:"Name"`
+	// Only relevant to register function fields
+	Bit          uint8            `json:"bit" mapstructure:"bit"`
+	FromHighByte bool             `json:"from_high_byte" mapstructure:"from_high_byte"`
+	Length       uint8            `json:"Length" mapstructure:"Length"`
+	ByteOrder    packet.ByteOrder `json:"byte_order" mapstructure:"byte_order"`
 }
 
 // registerSize returns how many register/words does this field would take in modbus response
@@ -77,7 +82,7 @@ func (f *Field) registerSize() uint16 {
 }
 
 // Validate checks if Field is values are correctly filled
-func (f Field) Validate() error {
+func (f *Field) Validate() error {
 	if f.ServerAddress == "" {
 		return errors.New("field server address can not be empty")
 	}
@@ -97,34 +102,34 @@ func (f Field) Validate() error {
 }
 
 // ExtractFrom extracts field value from given registers data
-func (f Field) ExtractFrom(registers *packet.Registers) (interface{}, error) {
+func (f *Field) ExtractFrom(registers *packet.Registers) (interface{}, error) {
 	switch f.Type {
 	case FieldTypeBit:
-		return registers.Bit(f.RegisterAddress, f.Bit)
+		return registers.Bit(f.Address, f.Bit)
 	case FieldTypeByte:
-		return registers.Byte(f.RegisterAddress, f.FromHighByte)
+		return registers.Byte(f.Address, f.FromHighByte)
 	case FieldTypeUint8:
-		return registers.Uint8(f.RegisterAddress, f.FromHighByte)
+		return registers.Uint8(f.Address, f.FromHighByte)
 	case FieldTypeInt8:
-		return registers.Int8(f.RegisterAddress, f.FromHighByte)
+		return registers.Int8(f.Address, f.FromHighByte)
 	case FieldTypeUint16:
-		return registers.Uint16(f.RegisterAddress)
+		return registers.Uint16(f.Address)
 	case FieldTypeInt16:
-		return registers.Int16(f.RegisterAddress)
+		return registers.Int16(f.Address)
 	case FieldTypeUint32:
-		return registers.Uint32WithByteOrder(f.RegisterAddress, f.ByteOrder)
+		return registers.Uint32WithByteOrder(f.Address, f.ByteOrder)
 	case FieldTypeInt32:
-		return registers.Int32WithByteOrder(f.RegisterAddress, f.ByteOrder)
+		return registers.Int32WithByteOrder(f.Address, f.ByteOrder)
 	case FieldTypeUint64:
-		return registers.Uint64WithByteOrder(f.RegisterAddress, f.ByteOrder)
+		return registers.Uint64WithByteOrder(f.Address, f.ByteOrder)
 	case FieldTypeInt64:
-		return registers.Int64WithByteOrder(f.RegisterAddress, f.ByteOrder)
+		return registers.Int64WithByteOrder(f.Address, f.ByteOrder)
 	case FieldTypeFloat32:
-		return registers.Float32WithByteOrder(f.RegisterAddress, f.ByteOrder)
+		return registers.Float32WithByteOrder(f.Address, f.ByteOrder)
 	case FieldTypeFloat64:
-		return registers.Float64WithByteOrder(f.RegisterAddress, f.ByteOrder)
+		return registers.Float64WithByteOrder(f.Address, f.ByteOrder)
 	case FieldTypeString:
-		return registers.StringWithByteOrder(f.RegisterAddress, f.Length, f.ByteOrder)
+		return registers.StringWithByteOrder(f.Address, f.Length, f.ByteOrder)
 	}
 	return nil, errors.New("extraction failure due unknown field type")
 }
@@ -196,8 +201,21 @@ func (b *Builder) Bit(registerAddress uint16, bit uint8) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeBit,
 
-			RegisterAddress: registerAddress,
-			Bit:             bit,
+			Address: registerAddress,
+			Bit:     bit,
+		},
+	}
+}
+
+// Coil adds discrete/coil field to Builder to be requested and extracted by FC1/FC2.
+func (b *Builder) Coil(address uint16) *BField {
+	return &BField{
+		Field{
+			ServerAddress: b.serverAddress,
+			UnitID:        b.unitID,
+			Type:          FieldTypeCoil,
+
+			Address: address,
 		},
 	}
 }
@@ -210,8 +228,8 @@ func (b *Builder) Byte(registerAddress uint16, fromHighByte bool) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeByte,
 
-			RegisterAddress: registerAddress,
-			FromHighByte:    fromHighByte,
+			Address:      registerAddress,
+			FromHighByte: fromHighByte,
 		},
 	}
 }
@@ -224,8 +242,8 @@ func (b *Builder) Uint8(registerAddress uint16, fromHighByte bool) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeUint8,
 
-			RegisterAddress: registerAddress,
-			FromHighByte:    fromHighByte,
+			Address:      registerAddress,
+			FromHighByte: fromHighByte,
 		},
 	}
 }
@@ -238,8 +256,8 @@ func (b *Builder) Int8(registerAddress uint16, fromHighByte bool) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeInt8,
 
-			RegisterAddress: registerAddress,
-			FromHighByte:    fromHighByte,
+			Address:      registerAddress,
+			FromHighByte: fromHighByte,
 		},
 	}
 }
@@ -252,7 +270,7 @@ func (b *Builder) Uint16(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeUint16,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -265,7 +283,7 @@ func (b *Builder) Int16(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeInt16,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -278,7 +296,7 @@ func (b *Builder) Uint32(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeUint32,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -291,7 +309,7 @@ func (b *Builder) Int32(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeInt32,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -304,7 +322,7 @@ func (b *Builder) Uint64(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeUint64,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -317,7 +335,7 @@ func (b *Builder) Int64(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeInt64,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -330,7 +348,7 @@ func (b *Builder) Float32(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeFloat32,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -343,7 +361,7 @@ func (b *Builder) Float64(registerAddress uint16) *BField {
 			UnitID:        b.unitID,
 			Type:          FieldTypeFloat64,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
@@ -357,13 +375,13 @@ func (b *Builder) String(registerAddress uint16, length uint8) *BField {
 			Type:          FieldTypeString,
 			Length:        length,
 
-			RegisterAddress: registerAddress,
+			Address: registerAddress,
 		},
 	}
 }
 
-// RegisterRequest helps to connect requested fields to responses
-type RegisterRequest struct {
+// BuilderRequest helps to connect requested fields to responses
+type BuilderRequest struct {
 	packet.Request
 
 	// ServerAddress is modbus server address where request should be sent
@@ -383,8 +401,14 @@ type RegistersResponse interface {
 	AsRegisters(requestStartAddress uint16) (*packet.Registers, error)
 }
 
+// CoilsResponse is marker interface for responses returning coil/discrete data
+type CoilsResponse interface {
+	packet.Response
+	IsCoilSet(startAddress uint16, coilAddress uint16) (bool, error)
+}
+
 // AsRegisters returns response data as Register to more convenient access
-func (r RegisterRequest) AsRegisters(response RegistersResponse) (*packet.Registers, error) {
+func (r BuilderRequest) AsRegisters(response RegistersResponse) (*packet.Registers, error) {
 	return response.AsRegisters(r.StartAddress)
 }
 
@@ -401,7 +425,17 @@ var ErrorFieldExtractHadError = errors.New("field extraction had an error. check
 // ExtractFields extracts Field values from given response. When continueOnExtractionErrors is true and error occurs
 // during extraction, this method does not end but continues to extract all Fields and returns ErrorFieldExtractHadError
 // at the end. To distinguish errors check FieldValue.Error field.
-func (r RegisterRequest) ExtractFields(response RegistersResponse, continueOnExtractionErrors bool) ([]FieldValue, error) {
+func (r BuilderRequest) ExtractFields(response packet.Response, continueOnExtractionErrors bool) ([]FieldValue, error) {
+	switch resp := response.(type) {
+	case RegistersResponse:
+		return r.extractRegisterFields(resp, continueOnExtractionErrors)
+	case CoilsResponse:
+		return r.extractCoilFields(resp, continueOnExtractionErrors)
+	}
+	return nil, errors.New("can not extract fields from unsupported response type")
+}
+
+func (r BuilderRequest) extractRegisterFields(response RegistersResponse, continueOnExtractionErrors bool) ([]FieldValue, error) {
 	regs, err := response.AsRegisters(r.StartAddress)
 	if err != nil {
 		return nil, err
@@ -434,22 +468,71 @@ func (r RegisterRequest) ExtractFields(response RegistersResponse, continueOnExt
 	return result, nil
 }
 
+func (r BuilderRequest) extractCoilFields(response CoilsResponse, continueOnExtractionErrors bool) ([]FieldValue, error) {
+	hadErrors := false
+	capacity := 0
+	if continueOnExtractionErrors {
+		capacity = len(r.Fields)
+	}
+	result := make([]FieldValue, 0, capacity)
+	for _, f := range r.Fields {
+		vTmp, err := response.IsCoilSet(r.StartAddress, f.Address)
+
+		if err != nil && !continueOnExtractionErrors {
+			return nil, fmt.Errorf("field extraction failed. name: %v err: %w", f.Name, err)
+		}
+		if !hadErrors && err != nil {
+			hadErrors = true
+		}
+		tmp := FieldValue{
+			Field: f,
+			Value: vTmp,
+			Error: err,
+		}
+		result = append(result, tmp)
+	}
+	if hadErrors {
+		return result, ErrorFieldExtractHadError
+	}
+	return result, nil
+}
+
 // ReadHoldingRegistersTCP combines fields into TCP Read Holding Registers (FC3) requests
-func (b *Builder) ReadHoldingRegistersTCP() ([]RegisterRequest, error) {
-	return split(b.fields, "fc3_tcp")
+func (b *Builder) ReadHoldingRegistersTCP() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC3TCP)
 }
 
 // ReadHoldingRegistersRTU combines fields into RTU Read Holding Registers (FC3) requests
-func (b *Builder) ReadHoldingRegistersRTU() ([]RegisterRequest, error) {
-	return split(b.fields, "fc3_rtu")
+func (b *Builder) ReadHoldingRegistersRTU() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC3RTU)
 }
 
 // ReadInputRegistersTCP combines fields into TCP Read Input Registers (FC4) requests
-func (b *Builder) ReadInputRegistersTCP() ([]RegisterRequest, error) {
-	return split(b.fields, "fc4_tcp")
+func (b *Builder) ReadInputRegistersTCP() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC4TCP)
 }
 
 // ReadInputRegistersRTU combines fields into RTU Read Input Registers (FC4) requests
-func (b *Builder) ReadInputRegistersRTU() ([]RegisterRequest, error) {
-	return split(b.fields, "fc4_rtu")
+func (b *Builder) ReadInputRegistersRTU() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC4RTU)
+}
+
+// ReadCoilsTCP combines fields into TCP Read Coils (FC1) requests
+func (b *Builder) ReadCoilsTCP() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC1TCP)
+}
+
+// ReadCoilsRTU combines fields into RTU Read Coils (FC1) requests
+func (b *Builder) ReadCoilsRTU() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC1RTU)
+}
+
+// ReadDiscreteInputsTCP combines fields into TCP Read Discrete Inputs (FC2) requests
+func (b *Builder) ReadDiscreteInputsTCP() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC2TCP)
+}
+
+// ReadDiscreteInputsRTU combines fields into RTU Read Discrete Inputs (FC2) requests
+func (b *Builder) ReadDiscreteInputsRTU() ([]BuilderRequest, error) {
+	return split(b.fields, splitToFC2RTU)
 }

--- a/examples/server_and_request_test.go
+++ b/examples/server_and_request_test.go
@@ -91,6 +91,9 @@ func doRequest(ctx context.Context, serverAddress string) error {
 		return err
 	}
 	uint16Var, err := registers.Uint16(11) // extract uint16 value from register 11
+	if err != nil {
+		return err
+	}
 	log.Printf("Received as register 11 value: %v (hex: %X)\n", uint16Var, uint16Var)
 
 	return nil

--- a/packet/packet.go
+++ b/packet/packet.go
@@ -11,6 +11,8 @@ const (
 
 	// MaxRegistersInReadResponse is maximum quantity of registers that can be returned by read request (fc03/fc04)
 	MaxRegistersInReadResponse = uint16(125)
+	// MaxCoilsInReadResponse is maximum quantity of discretes/coils that can be returned by read request (fc01/fc02)
+	MaxCoilsInReadResponse = uint16(2000) // 2000/8=250 bytes
 )
 
 const (

--- a/packet/readcoilsrequest.go
+++ b/packet/readcoilsrequest.go
@@ -43,7 +43,7 @@ type ReadCoilsRequest struct {
 
 // NewReadCoilsRequestTCP creates new instance of Read Coils TCP request
 func NewReadCoilsRequestTCP(unitID uint8, startAddress uint16, quantity uint16) (*ReadCoilsRequestTCP, error) {
-	if quantity == 0 || quantity > 2000 {
+	if quantity == 0 || quantity > MaxCoilsInReadResponse {
 		// 2000 coils is due that in response data size field is 1 byte so max 250*8=2000 coils can be returned
 		return nil, fmt.Errorf("quantity is out of range (1-2000): %v", quantity)
 	}
@@ -112,7 +112,7 @@ func ParseReadCoilsRequestTCP(data []byte) (*ReadCoilsRequestTCP, error) {
 
 // NewReadCoilsRequestRTU creates new instance of Read Coils RTU request
 func NewReadCoilsRequestRTU(unitID uint8, startAddress uint16, quantity uint16) (*ReadCoilsRequestRTU, error) {
-	if quantity == 0 || quantity > 2000 {
+	if quantity == 0 || quantity > MaxCoilsInReadResponse {
 		// 2000 coils is due that in response data size field is 1 byte so max 250*8=2000 coils can be returned
 		return nil, fmt.Errorf("quantity is out of range (1-2000): %v", quantity)
 	}

--- a/packet/readdiscreteinputsrequest.go
+++ b/packet/readdiscreteinputsrequest.go
@@ -43,7 +43,7 @@ type ReadDiscreteInputsRequest struct {
 
 // NewReadDiscreteInputsRequestTCP creates new instance of Read Discrete Inputs TCP request
 func NewReadDiscreteInputsRequestTCP(unitID uint8, startAddress uint16, quantity uint16) (*ReadDiscreteInputsRequestTCP, error) {
-	if quantity == 0 || quantity > 2000 {
+	if quantity == 0 || quantity > MaxCoilsInReadResponse {
 		// 2000 coils is due that in response data size field is 1 byte so max 250*8=2000 coils can be returned
 		return nil, fmt.Errorf("quantity is out of range (1-2000): %v", quantity)
 	}
@@ -112,7 +112,7 @@ func ParseReadDiscreteInputsRequestTCP(data []byte) (*ReadDiscreteInputsRequestT
 
 // NewReadDiscreteInputsRequestRTU creates new instance of Read Discrete Inputs RTU request
 func NewReadDiscreteInputsRequestRTU(unitID uint8, startAddress uint16, quantity uint16) (*ReadDiscreteInputsRequestRTU, error) {
-	if quantity == 0 || quantity > 2000 {
+	if quantity == 0 || quantity > MaxCoilsInReadResponse {
 		// 2000 coils is due that in response data size field is 1 byte so max 250*8=2000 coils can be returned
 		return nil, fmt.Errorf("quantity is out of range (1-2000): %v", quantity)
 	}

--- a/packet/readdiscreteinputsresponse.go
+++ b/packet/readdiscreteinputsresponse.go
@@ -131,3 +131,8 @@ func (r ReadDiscreteInputsResponse) bytes(data []byte) []byte {
 func (r ReadDiscreteInputsResponse) IsInputSet(startAddress uint16, inputAddress uint16) (bool, error) {
 	return isBitSet(r.Data, startAddress, inputAddress)
 }
+
+// IsCoilSet checks if N-th discrete input is set in response data. It is alias to IsInputSet method.
+func (r ReadDiscreteInputsResponse) IsCoilSet(startAddress uint16, inputAddress uint16) (bool, error) {
+	return r.IsInputSet(startAddress, inputAddress)
+}

--- a/packet/readdiscreteinputsresponse_test.go
+++ b/packet/readdiscreteinputsresponse_test.go
@@ -261,7 +261,7 @@ func TestReadDiscreteInputsResponse_Bytes(t *testing.T) {
 	}
 }
 
-func TestReadDiscreteInputsResponse_IsCoilSet(t *testing.T) {
+func TestReadDiscreteInputsResponse_IsInputSet(t *testing.T) {
 	var testCases = []struct {
 		name             string
 		whenStartAddress uint16
@@ -311,6 +311,67 @@ func TestReadDiscreteInputsResponse_IsCoilSet(t *testing.T) {
 				Data:             []byte{0b10000001, 0b00010010},
 			}
 			result, err := given.IsInputSet(tc.whenStartAddress, tc.whenCoilAddress)
+
+			assert.Equal(t, tc.expect, result)
+			if tc.expectError != "" {
+				assert.EqualError(t, err, tc.expectError)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestReadDiscreteInputsResponse_IsCoilSet(t *testing.T) {
+	var testCases = []struct {
+		name             string
+		whenStartAddress uint16
+		whenCoilAddress  uint16
+		expect           bool
+		expectError      string
+	}{
+		{
+			name:             "ok, first byte, second bit",
+			whenStartAddress: 0, whenCoilAddress: 1, expect: true,
+		},
+		{
+			name:             "ok, first byte, second bit, start 1",
+			whenStartAddress: 1, whenCoilAddress: 2, expect: true},
+		{
+			name:             "ok, first byte, second bit, start 100",
+			whenStartAddress: 100, whenCoilAddress: 101, expect: true,
+		},
+		{
+			name:             "ok, first byte, third bit",
+			whenStartAddress: 0, whenCoilAddress: 2, expect: false,
+		},
+		{
+			name:             "ok, second byte, first bit",
+			whenStartAddress: 0, whenCoilAddress: 8, expect: true,
+		},
+		{
+			name:             "ok, second byte, last bit",
+			whenStartAddress: 0, whenCoilAddress: 15, expect: true,
+		},
+		{
+			name:             "ok, bit out of bounds",
+			whenStartAddress: 0, whenCoilAddress: 16, expect: false,
+			expectError: "bit value more than data contains bits",
+		},
+		{
+			name:             "ok, bit before start coil",
+			whenStartAddress: 10, whenCoilAddress: 9, expect: false,
+			expectError: "bit can not be before startBit",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			given := ReadDiscreteInputsResponse{
+				InputsByteLength: 2,
+				Data:             []byte{0b10000001, 0b00010010},
+			}
+			result, err := given.IsCoilSet(tc.whenStartAddress, tc.whenCoilAddress)
 
 			assert.Equal(t, tc.expect, result)
 			if tc.expectError != "" {

--- a/server/server.go
+++ b/server/server.go
@@ -254,7 +254,7 @@ func (c *connection) handle(ctx context.Context) {
 		}
 		if n > 0 {
 			lastReceived = time.Now()
-		} else if time.Now().Sub(lastReceived) > idleTimeout {
+		} else if time.Since(lastReceived) > idleTimeout {
 			c.onErrorFunc(ErrServerIdleTimeout)
 			return // close idle connection
 		} else {

--- a/splitter.go
+++ b/splitter.go
@@ -6,100 +6,131 @@ import (
 	"sort"
 )
 
+type splitToFuncType uint8
+
+const (
+	splitToFC1TCP splitToFuncType = iota
+	splitToFC1RTU
+	splitToFC2TCP
+	splitToFC2RTU
+	splitToFC3TCP
+	splitToFC3RTU
+	splitToFC4TCP
+	splitToFC4RTU
+)
+
 // split groups (by host:port+UnitID, "optimized" max amount of fields for max quantity) fields into packets
-func split(fields []Field, funcType string) ([]RegisterRequest, error) {
-	connectionGroup, err := groupForSingleConnection(fields)
+func split(fields []Field, funcType splitToFuncType) ([]BuilderRequest, error) {
+	onlyCoils := funcType == splitToFC1TCP || funcType == splitToFC1RTU || funcType == splitToFC2TCP || funcType == splitToFC2RTU
+	connectionGroup, err := groupForSingleConnection(fields, onlyCoils)
 	if err != nil {
 		return nil, err
 	}
 	batches := batchToRequests(connectionGroup)
 
-	result := make([]RegisterRequest, len(batches))
-	for i, b := range batches {
+	result := make([]BuilderRequest, 0, len(batches))
+	for _, b := range batches {
 		var req packet.Request
 		var err error
 		switch funcType {
-		case "fc3_tcp":
+		case splitToFC1TCP:
+			req, err = packet.NewReadCoilsRequestTCP(b.UnitID, b.StartAddress, b.Quantity)
+		case splitToFC1RTU:
+			req, err = packet.NewReadCoilsRequestRTU(b.UnitID, b.StartAddress, b.Quantity)
+
+		case splitToFC2TCP:
+			req, err = packet.NewReadDiscreteInputsRequestTCP(b.UnitID, b.StartAddress, b.Quantity)
+		case splitToFC2RTU:
+			req, err = packet.NewReadDiscreteInputsRequestRTU(b.UnitID, b.StartAddress, b.Quantity)
+
+		case splitToFC3TCP:
 			req, err = packet.NewReadHoldingRegistersRequestTCP(b.UnitID, b.StartAddress, b.Quantity)
-		case "fc3_rtu":
+		case splitToFC3RTU:
 			req, err = packet.NewReadHoldingRegistersRequestRTU(b.UnitID, b.StartAddress, b.Quantity)
-		case "fc4_tcp":
+
+		case splitToFC4TCP:
 			req, err = packet.NewReadInputRegistersRequestTCP(b.UnitID, b.StartAddress, b.Quantity)
-		case "fc4_rtu":
+		case splitToFC4RTU:
 			req, err = packet.NewReadInputRegistersRequestRTU(b.UnitID, b.StartAddress, b.Quantity)
 		}
 		if err != nil {
 			return nil, err
 		}
-		result[i] = RegisterRequest{
+		result = append(result, BuilderRequest{
 			Request: req,
 
 			ServerAddress: b.Address,
 			UnitID:        b.UnitID,
 			StartAddress:  b.StartAddress,
 			Fields:        b.fields,
-		}
+		})
 	}
 	return result, nil
 }
 
-// groupForSingleConnection groups fields into groups what can be requested within same/single connection/request
-func groupForSingleConnection(fields []Field) (map[string]map[uint16]registerSlot, error) {
-	result := map[string]map[uint16]registerSlot{}
+// groupForSingleConnection groups fields into groups what can be requested potentially by same request (same server + unit ID + function)
+func groupForSingleConnection(fields []Field, onlyCoils bool) ([]builderSlotGroup, error) {
+	groups := map[string]builderSlotGroup{}
 	for _, f := range fields {
 		if err := f.Validate(); err != nil {
 			return nil, err
 		}
-		// create groups by modbus Address + unitID ... and on second level by register Address
-		gID := fmt.Sprintf("%v_%v", f.ServerAddress, f.UnitID)
-		group, ok := result[gID]
-		if !ok {
-			group = map[uint16]registerSlot{}
-			result[gID] = group
+		// create groups by modbus server Address + unitID + isCoil
+		isCoil := f.Type == FieldTypeCoil
+		if onlyCoils && !isCoil {
+			continue
+		} else if !onlyCoils && isCoil {
+			continue
 		}
 
-		registerSize := f.registerSize()
-		slot, ok := group[f.RegisterAddress]
+		gID := fmt.Sprintf("%v_%v_%v", f.ServerAddress, f.UnitID, isCoil)
+		group, ok := groups[gID]
 		if !ok {
-			slot = registerSlot{
-				registerAddress: f.RegisterAddress,
-				size:            registerSize,
-				fields:          Fields{},
+			group = builderSlotGroup{
+				serverAddress: f.ServerAddress,
+				unitID:        f.UnitID,
+				isForCoils:    isCoil,
+				slots:         make([]builderSlot, 0),
 			}
+			groups[gID] = group
 		}
-		if registerSize > slot.size {
-			slot.size = registerSize
-		}
-		slot.fields = append(slot.fields, f)
-		group[f.RegisterAddress] = slot
+
+		group.AddField(f)
+		groups[gID] = group
+	}
+	// TODO: as of Go 1.23 this could be shortened to `slices.Collect(maps.Values(groups))`
+	result := make([]builderSlotGroup, 0, len(groups))
+	for _, g := range groups {
+		result = append(result, g)
 	}
 	return result, nil
 }
 
-func batchToRequests(connectionGroup map[string]map[uint16]registerSlot) []requestBatch {
+func batchToRequests(connectionGroup []builderSlotGroup) []requestBatch {
+	// Coils are always grouped to separate requests (fc1/fc2) from fields suitable for registers (fc3/fc4)
+	//
 	// NB: is batching/grouping algorithm is very naive. It just sorts fields by register and creates N number
 	// of requests of them by limiting quantity to MaxRegistersInReadResponse. It does not try to optimise long caps
 	// between fields
 	// assumes that UnitID is same for all fields within group
 
 	var result = make([]requestBatch, 0)
-	for _, group := range connectionGroup {
-		groupByAddress := slotsSorter{}
-		for _, slot := range group {
-			groupByAddress = append(groupByAddress, slot)
+	for _, slotGroup := range connectionGroup {
+		address := slotGroup.serverAddress
+		unitID := slotGroup.unitID
+		addressLimit := packet.MaxRegistersInReadResponse
+		if slotGroup.isForCoils {
+			addressLimit = packet.MaxCoilsInReadResponse
 		}
-		sort.Sort(groupByAddress)
-
-		address := groupByAddress[0].fields[0].ServerAddress
-		unitID := groupByAddress[0].fields[0].UnitID
+		sort.Sort(slotsSorter(slotGroup.slots))
 
 		batch := requestBatch{}
 		isFirstSeen := false
 		var firstAddress uint16
-		for _, slot := range groupByAddress {
-			registerAddress := slot.registerAddress
+		for _, slot := range slotGroup.slots {
+			slotAddress := slot.address
 			if !isFirstSeen {
-				firstAddress = registerAddress
+				firstAddress = slotAddress
 				isFirstSeen = true
 
 				batch.StartAddress = firstAddress
@@ -107,17 +138,17 @@ func batchToRequests(connectionGroup map[string]map[uint16]registerSlot) []reque
 				batch.UnitID = unitID
 			}
 
-			slotEndRegister := registerAddress + slot.size
-			addressDiff := slotEndRegister - firstAddress
-			if addressDiff > packet.MaxRegistersInReadResponse {
+			slotEndAddress := slotAddress + slot.size
+			addressDiff := slotEndAddress - firstAddress
+			if addressDiff > addressLimit {
 				result = append(result, batch)
 
 				batch = requestBatch{
 					Address:      address,
 					UnitID:       unitID,
-					StartAddress: registerAddress,
+					StartAddress: slotAddress,
 				}
-				firstAddress = registerAddress
+				firstAddress = slotAddress
 				addressDiff = slot.size
 			}
 			if batch.Quantity < addressDiff {
@@ -131,18 +162,58 @@ func batchToRequests(connectionGroup map[string]map[uint16]registerSlot) []reque
 	return result
 }
 
-type registerSlot struct {
-	registerAddress uint16
-	size            uint16
-	fields          Fields
+type builderSlot struct {
+	address uint16
+	size    uint16
+	fields  Fields
 }
 
-type slotsSorter []registerSlot
+type builderSlots []builderSlot
+
+func (bs *builderSlots) IndexOf(address uint16) int {
+	for i, b := range *bs {
+		if b.address == address {
+			return i
+		}
+	}
+	return -1
+}
+
+type slotsSorter builderSlots
 
 func (a slotsSorter) Len() int      { return len(a) }
 func (a slotsSorter) Swap(i, j int) { a[i], a[j] = a[j], a[i] }
 func (a slotsSorter) Less(i, j int) bool {
-	return a[i].registerAddress < a[j].registerAddress
+	return a[i].address < a[j].address
+}
+
+type builderSlotGroup struct {
+	serverAddress string
+	unitID        uint8
+	isForCoils    bool
+
+	slots builderSlots
+}
+
+func (g *builderSlotGroup) AddField(f Field) {
+	registerSize := f.registerSize()
+	i := g.slots.IndexOf(f.Address)
+	if i == -1 {
+		g.slots = append(g.slots, builderSlot{
+			address: f.Address,
+			size:    registerSize,
+			fields:  Fields{f},
+		})
+		return
+	}
+
+	slot := g.slots[i]
+
+	slot.fields = append(slot.fields, f)
+	if registerSize > slot.size {
+		slot.size = registerSize
+	}
+	g.slots[i] = slot
 }
 
 type requestBatch struct {
@@ -150,6 +221,8 @@ type requestBatch struct {
 	UnitID       uint8
 	StartAddress uint16
 	Quantity     uint16
+
+	IsForCoils bool
 
 	fields Fields
 }

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -10,15 +10,15 @@ func TestSplit_validationError(t *testing.T) {
 	given := []Field{
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 1, Type: FieldTypeInt8,
+			Address: 1, Type: FieldTypeInt8,
 		},
 		{
 			ServerAddress: "", UnitID: 0, // ServerAddress is empty
-			RegisterAddress: 1, Type: FieldTypeInt8,
+			Address: 1, Type: FieldTypeInt8,
 		},
 	}
 
-	batched, err := split(given, "fc3_tcp")
+	batched, err := split(given, splitToFC3TCP)
 	assert.EqualError(t, err, "field server address can not be empty")
 	assert.Nil(t, batched)
 }
@@ -27,24 +27,24 @@ func TestSplit_single(t *testing.T) {
 	given := []Field{
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 1, Type: FieldTypeInt8,
+			Address: 1, Type: FieldTypeInt8,
 		},
 	}
 
-	batched, err := split(given, "fc3_tcp")
+	batched, err := split(given, splitToFC3TCP)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 1)
 
 	pReq, _ := packet.NewReadHoldingRegistersRequestTCP(0, 1, 1)
 	pReq.TransactionID = 123
-	expect := RegisterRequest{
+	expect := BuilderRequest{
 		ServerAddress: ":502",
 		StartAddress:  1,
 		Request:       pReq,
 		Fields: []Field{
 			{
 				ServerAddress: ":502", UnitID: 0,
-				RegisterAddress: 1, Type: FieldTypeInt8,
+				Address: 1, Type: FieldTypeInt8,
 			},
 		},
 	}
@@ -56,23 +56,27 @@ func TestSplit_many(t *testing.T) {
 	given := []Field{
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 1, Type: FieldTypeInt8,
+			Address: 1, Type: FieldTypeInt8,
 		},
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 118, Length: 11, Type: FieldTypeString, // 118 + 6 + 124
+			Address: 118, Length: 11, Type: FieldTypeString, // 118 + 6 + 124
 		},
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 121, Type: FieldTypeUint64,
+			Address: 121, Type: FieldTypeUint64,
 		},
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 122, Type: FieldTypeFloat32,
+			Address: 122, Type: FieldTypeInt16,
+		},
+		{
+			ServerAddress: ":502", UnitID: 0,
+			Address: 122, Type: FieldTypeFloat32,
 		},
 	}
 
-	batched, err := split(given, "fc3_tcp")
+	batched, err := split(given, splitToFC3TCP)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 1)
 
@@ -83,27 +87,31 @@ func TestSplit_many(t *testing.T) {
 	assert.Equal(t, expect, batched[0].Request)
 }
 
-func TestSplit_to2batches(t *testing.T) {
+func TestSplit_to2RegisterBatches(t *testing.T) {
 	given := []Field{
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 1, Type: FieldTypeInt8,
+			Address: 1, Type: FieldTypeInt8,
 		},
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 119, Length: 15, Type: FieldTypeString, // 119,120,121,122, 123,124,125,126 == new request
+			Address: 119, Length: 15, Type: FieldTypeString, // 119,120,121,122, 123,124,125,126 == new request
 		},
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 121, Type: FieldTypeUint64, // 121,122,123,124
+			Address: 121, Type: FieldTypeUint64, // 121,122,123,124
 		},
 		{
 			ServerAddress: ":502", UnitID: 0,
-			RegisterAddress: 122, Type: FieldTypeFloat32, // 122, 123
+			Address: 122, Type: FieldTypeFloat32, // 122, 123
+		},
+		{
+			ServerAddress: ":502", UnitID: 0,
+			Address: 1, Type: FieldTypeCoil, // should be ignored
 		},
 	}
 
-	batched, err := split(given, "fc3_tcp")
+	batched, err := split(given, splitToFC3TCP)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 2)
 
@@ -122,4 +130,49 @@ func TestSplit_to2batches(t *testing.T) {
 	secondBatch.Request.(*packet.ReadHoldingRegistersRequestTCP).TransactionID = 124
 	assert.Equal(t, expect2, secondBatch.Request)
 	assert.Len(t, secondBatch.Fields, 3)
+}
+
+func TestSplit_to2CoilsBatches(t *testing.T) {
+	given := []Field{
+		{
+			ServerAddress: ":502", UnitID: 0,
+			Address: 1, Type: FieldTypeCoil,
+		},
+		{
+			ServerAddress: ":502", UnitID: 0,
+			Address: 1, Type: FieldTypeCoil, // at same place previous field
+		},
+		{
+			ServerAddress: ":502", UnitID: 0,
+			Address: 100, Type: FieldTypeCoil,
+		},
+		{
+			ServerAddress: ":502", UnitID: 0,
+			Address: 2001, Type: FieldTypeCoil, // should go to next batch
+		},
+		{
+			ServerAddress: ":502", UnitID: 0,
+			Address: 122, Type: FieldTypeFloat32, // should be ignored
+		},
+	}
+
+	batched, err := split(given, splitToFC1TCP)
+	assert.NoError(t, err)
+	assert.Len(t, batched, 2)
+
+	expect, _ := packet.NewReadCoilsRequestTCP(0, 1, 100)
+	expect.TransactionID = 123
+
+	firstBatch := batched[0]
+	firstBatch.Request.(*packet.ReadCoilsRequestTCP).TransactionID = 123
+	assert.Equal(t, expect, firstBatch.Request)
+	assert.Len(t, firstBatch.Fields, 3)
+
+	expect2, _ := packet.NewReadCoilsRequestTCP(0, 2001, 1)
+	expect2.TransactionID = 124
+
+	secondBatch := batched[1]
+	secondBatch.Request.(*packet.ReadCoilsRequestTCP).TransactionID = 124
+	assert.Equal(t, expect2, secondBatch.Request)
+	assert.Len(t, secondBatch.Fields, 1)
 }


### PR DESCRIPTION
NB: there are breaking changes to APIs. See changelog.


Builder should be able to split fc1/fc2 coil fields to batches.  

We do this by instruducing new builder field type and for that `b.Coil(coilAddress)` method. For fc1/fc2 there are new methods like `ReadCoilsTCP`/`ReadDiscreteInputsTCP`. You can add other types at the same time but current implementation will just ignore register fields when dealing with coils.

```go
	reqs, err := b.Add(b.Coil(19).Name("alarm_do_1").UnitID(0)).
		ReadCoilsTCP()
```
