### PR TITLE
Add Quantity field to BuilderRequest + poller single connection

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -164,6 +164,8 @@ type BuilderRequest struct {
 	UnitID uint8
 	// StartAddress is start register address for request
 	StartAddress uint16
+	// Quantity is amount of registers/coils to return with request
+	Quantity uint16
 
 	Protocol        ProtocolType
 	RequestInterval time.Duration

--- a/field.go
+++ b/field.go
@@ -126,7 +126,7 @@ type Field struct {
 	// fields into request batches.
 	//
 	// Splitter logic know following query parameters:
-	// - `max_quantity_per_request` maximum quantity that request can have. How many
+	// - `max_quantity_per_request` maximum quantity (uint16) that request can have. How many
 	//		registers/coils requests will be limited to.
 	// - `invalid_addr=70,100-120` - addresses or address range that splitter will avoid to include in request
 	//		when creating batches.

--- a/poller/singleconnection.go
+++ b/poller/singleconnection.go
@@ -1,0 +1,95 @@
+package poller
+
+import (
+	"context"
+	"github.com/aldas/go-modbus-client"
+	"github.com/aldas/go-modbus-client/packet"
+	"strings"
+	"sync"
+)
+
+type singleConnectionPerAddress struct {
+	mu            sync.Mutex
+	clientPool    map[string]*sharedClient
+	newClientFunc ClientConnectFunc
+}
+
+// NewSingleConnectionPerAddressClientFunc creates clients that limit themselves to single instance
+// per server address and use mutexes to guard against parallel Client.Do invocations.
+// Use-case for this is connections to serial devices where you can not run multiple requests in parallel.
+func NewSingleConnectionPerAddressClientFunc(newClientFunc ClientConnectFunc) ClientConnectFunc {
+	pool := &singleConnectionPerAddress{
+		newClientFunc: newClientFunc,
+		clientPool:    map[string]*sharedClient{},
+	}
+	return pool.NewClientFunc
+}
+
+func (scp *singleConnectionPerAddress) NewClientFunc(ctx context.Context, protocol modbus.ProtocolType, address string) (Client, error) {
+	scp.mu.Lock()
+	defer scp.mu.Unlock()
+
+	// address could have params `tcp://192.168.1.2:502??invalid_addr=70`
+	if i := strings.IndexByte(address, '?'); i != -1 {
+		address = address[:i]
+	}
+	client, ok := scp.clientPool[address]
+	if ok {
+		return client, nil
+	}
+
+	orgClient, err := scp.newClientFunc(ctx, protocol, address)
+	if err != nil {
+		return nil, err
+	}
+
+	client = &sharedClient{
+		mu:      sync.Mutex{},
+		client:  orgClient,
+		address: address,
+		onClose: scp.onClose,
+	}
+	scp.clientPool[address] = client
+	return client, nil
+}
+
+func (scp *singleConnectionPerAddress) onClose(address string) {
+	scp.mu.Lock()
+	defer scp.mu.Unlock()
+
+	delete(scp.clientPool, address)
+}
+
+type sharedClient struct {
+	mu      sync.Mutex
+	client  Client
+	address string
+	onClose func(address string)
+}
+
+func (c *sharedClient) Do(ctx context.Context, req packet.Request) (packet.Response, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client == nil {
+		return nil, modbus.ErrClientNotConnected
+	}
+
+	return c.client.Do(ctx, req)
+}
+
+func (c *sharedClient) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.client == nil {
+		return nil
+	}
+
+	err := c.client.Close()
+	c.client = nil
+
+	c.onClose(c.address)
+
+	return err
+}

--- a/poller/singleconnection_test.go
+++ b/poller/singleconnection_test.go
@@ -1,0 +1,29 @@
+package poller
+
+import (
+	"context"
+	"github.com/aldas/go-modbus-client"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestNewSingleConnectionPerAddressClientFunc(t *testing.T) {
+	calledCount := 0
+	clientFunc := NewSingleConnectionPerAddressClientFunc(func(ctx context.Context, protocol modbus.ProtocolType, addressURL string) (Client, error) {
+		c := new(mockClient)
+		c.doCount = 999
+		calledCount++
+		return c, nil
+	})
+
+	ctx := context.Background()
+
+	address := "localhost:502?max_quantity_per_request=16"
+	client1, err := clientFunc(ctx, modbus.ProtocolTCP, address)
+	assert.NoError(t, err)
+	client2, err := clientFunc(ctx, modbus.ProtocolTCP, address)
+	assert.NoError(t, err)
+
+	assert.Equal(t, &client1, &client2)
+	assert.Equal(t, 1, calledCount)
+}

--- a/splitter.go
+++ b/splitter.go
@@ -65,12 +65,34 @@ func split(fields []Field, functionCode uint8, protocol ProtocolType) ([]Builder
 		if err != nil {
 			return nil, err
 		}
+		var quantity uint16
+		switch r := req.(type) {
+		case *packet.ReadCoilsRequestTCP: // fc1
+			quantity = r.Quantity
+		case *packet.ReadCoilsRequestRTU: // fc1
+			quantity = r.Quantity
+		case *packet.ReadDiscreteInputsRequestTCP: // fc2
+			quantity = r.Quantity
+		case *packet.ReadDiscreteInputsRequestRTU: // fc2
+			quantity = r.Quantity
+		case *packet.ReadHoldingRegistersRequestTCP: // fc3
+			quantity = r.Quantity
+		case *packet.ReadHoldingRegistersRequestRTU: // fc3
+			quantity = r.Quantity
+		case *packet.ReadInputRegistersRequestTCP: // fc4
+			quantity = r.Quantity
+		case *packet.ReadInputRegistersRequestRTU: // fc4
+			quantity = r.Quantity
+		}
+
 		result = append(result, BuilderRequest{
 			Request: req,
 
-			ServerAddress:   b.ServerAddress,
-			UnitID:          b.UnitID,
-			StartAddress:    b.StartAddress,
+			ServerAddress: b.ServerAddress,
+			UnitID:        b.UnitID,
+			StartAddress:  b.StartAddress,
+			Quantity:      quantity,
+
 			Protocol:        b.Protocol,
 			RequestInterval: time.Duration(b.RequestInterval),
 

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -39,6 +39,7 @@ func TestSplit_single(t *testing.T) {
 	expect := BuilderRequest{
 		ServerAddress: ":502",
 		StartAddress:  1,
+		Quantity:      1,
 		Protocol:      ProtocolTCP,
 		Request:       pReq,
 		Fields: []Field{


### PR DESCRIPTION
Add Quantity field to BuilderRequest + poller single connection per address

Relates to https://github.com/aldas/go-modbus-client/discussions/23