### PR TITLE
expose ParseNetworkAddress as public API

### DIFF
--- a/poller/poller.go
+++ b/poller/poller.go
@@ -320,7 +320,9 @@ func (j *job) poll(ctx context.Context) error {
 	}
 }
 
-func parseAddress(addressURL string) (string, modbus.ClientConfig, error) {
+// ParseNetworkAddress parses given address to modbus.ClientConfig suitable for use with TCP/UDP clients
+// Returned address is formatted as valid URL "scheme://host:port", where scheme default to `tcp` and port to `502`.
+func ParseNetworkAddress(addressURL string) (address string, config modbus.ClientConfig, err error) {
 	if !strings.Contains(addressURL, "://") {
 		addressURL = "tcp://" + addressURL
 	}
@@ -341,7 +343,7 @@ func parseAddress(addressURL string) (string, modbus.ClientConfig, error) {
 	if err != nil {
 		return "", modbus.ClientConfig{}, err
 	}
-	config := modbus.ClientConfig{
+	config = modbus.ClientConfig{
 		WriteTimeout: writeTimeout,
 		ReadTimeout:  readTimeout,
 	}
@@ -350,7 +352,7 @@ func parseAddress(addressURL string) (string, modbus.ClientConfig, error) {
 
 // DefaultConnectClient is default implementation to create and connect to Modbus server
 func DefaultConnectClient(ctx context.Context, protocol modbus.ProtocolType, addressURL string) (Client, error) {
-	addr, config, err := parseAddress(addressURL)
+	addr, config, err := ParseNetworkAddress(addressURL)
 	if err != nil {
 		return nil, err
 	}

--- a/poller/poller_test.go
+++ b/poller/poller_test.go
@@ -221,7 +221,7 @@ func TestPoller_PollWithError(t *testing.T) {
 	}
 }
 
-func TestParseAddress(t *testing.T) {
+func TestParseNetworkAddress(t *testing.T) {
 	defaultConf := modbus.ClientConfig{
 		WriteTimeout: 1 * time.Second,
 		ReadTimeout:  1 * time.Second,
@@ -272,7 +272,7 @@ func TestParseAddress(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			addr, conf, err := parseAddress(tc.whenAddressURL)
+			addr, conf, err := ParseNetworkAddress(tc.whenAddressURL)
 
 			assert.Equal(t, tc.expectAddr, addr)
 			assert.Equal(t, tc.expectConf, conf)


### PR DESCRIPTION
expose ParseNetworkAddress as public API so ClientFuncs can be created more easily