### PR TITLE
add Splitter interface and default implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,8 @@ func main() {
 		FunctionCode:  packet.FunctionReadHoldingRegisters, // fc3
 		UnitID:        1,
 		Protocol:      modbus.ProtocolTCP,
-		Interval:      modbus.Duration(1 * time.Second), // send request every 1 second
+		Interval:      modbus.Duration(1 * time.Second), // send a request every 1 second
+		Splitter:      nil, // allows custom splitter logic to be used
 	})
 
 	batches, _ := b.

--- a/bfield.go
+++ b/bfield.go
@@ -1,8 +1,9 @@
 package modbus
 
 import (
-	"github.com/aldas/go-modbus-client/packet"
 	"time"
+
+	"github.com/aldas/go-modbus-client/packet"
 )
 
 // BField is distinct field be requested and extracted from response

--- a/builder.go
+++ b/builder.go
@@ -122,6 +122,9 @@ type BuilderDefaults struct {
 	UnitID   uint8        `json:"unit_id" mapstructure:"unit_id"`
 	Protocol ProtocolType `json:"protocol" mapstructure:"protocol"`
 	Interval Duration     `json:"interval" mapstructure:"interval"`
+
+	// Splitter is used to split fields into requests. If nil DefaultSplitter is used.
+	Splitter Splitter
 }
 
 // NewRequestBuilderWithConfig creates new instance of Builder with given defaults.
@@ -310,47 +313,56 @@ func (r BuilderRequest) extractCoilFields(response CoilsResponse, continueOnExtr
 	return result, nil
 }
 
-// Split combines fields into requests by their ServerAddress+FunctionCode+UnitID+Protocol+RequestInterval
+// Split combines Fields into requests by their ServerAddress+FunctionCode+UnitID+Protocol+RequestInterval
+func (b *Builder) split(functionCode uint8, protocol ProtocolType) ([]BuilderRequest, error) {
+	s := b.config.Splitter
+	if s == nil {
+		s = DefaultSplitter{}
+	}
+	return s.Split(b.fields, functionCode, protocol)
+}
+
+// Split combines Fields into requests by their ServerAddress+FunctionCode+UnitID+Protocol+RequestInterval
 func (b *Builder) Split() ([]BuilderRequest, error) {
-	return split(b.fields, 0, protocolAny)
+	return b.split(0, protocolAny)
 }
 
-// ReadHoldingRegistersTCP combines fields into TCP Read Holding Registers (FC3) requests
+// ReadHoldingRegistersTCP combines Fields into TCP Read Holding Registers (FC3) requests
 func (b *Builder) ReadHoldingRegistersTCP() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadHoldingRegisters, ProtocolTCP)
+	return b.split(packet.FunctionReadHoldingRegisters, ProtocolTCP)
 }
 
-// ReadHoldingRegistersRTU combines fields into RTU Read Holding Registers (FC3) requests
+// ReadHoldingRegistersRTU combines Fields into RTU Read Holding Registers (FC3) requests
 func (b *Builder) ReadHoldingRegistersRTU() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadHoldingRegisters, ProtocolRTU)
+	return b.split(packet.FunctionReadHoldingRegisters, ProtocolRTU)
 }
 
-// ReadInputRegistersTCP combines fields into TCP Read Input Registers (FC4) requests
+// ReadInputRegistersTCP combines Fields into TCP Read Input Registers (FC4) requests
 func (b *Builder) ReadInputRegistersTCP() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadInputRegisters, ProtocolTCP)
+	return b.split(packet.FunctionReadInputRegisters, ProtocolTCP)
 }
 
-// ReadInputRegistersRTU combines fields into RTU Read Input Registers (FC4) requests
+// ReadInputRegistersRTU combines Fields into RTU Read Input Registers (FC4) requests
 func (b *Builder) ReadInputRegistersRTU() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadInputRegisters, ProtocolRTU)
+	return b.split(packet.FunctionReadInputRegisters, ProtocolRTU)
 }
 
-// ReadCoilsTCP combines fields into TCP Read Coils (FC1) requests
+// ReadCoilsTCP combines Fields into TCP Read Coils (FC1) requests
 func (b *Builder) ReadCoilsTCP() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadCoils, ProtocolTCP)
+	return b.split(packet.FunctionReadCoils, ProtocolTCP)
 }
 
-// ReadCoilsRTU combines fields into RTU Read Coils (FC1) requests
+// ReadCoilsRTU combines Fields into RTU Read Coils (FC1) requests
 func (b *Builder) ReadCoilsRTU() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadCoils, ProtocolRTU)
+	return b.split(packet.FunctionReadCoils, ProtocolRTU)
 }
 
-// ReadDiscreteInputsTCP combines fields into TCP Read Discrete Inputs (FC2) requests
+// ReadDiscreteInputsTCP combines Fields into TCP Read Discrete Inputs (FC2) requests
 func (b *Builder) ReadDiscreteInputsTCP() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadDiscreteInputs, ProtocolTCP)
+	return b.split(packet.FunctionReadDiscreteInputs, ProtocolTCP)
 }
 
-// ReadDiscreteInputsRTU combines fields into RTU Read Discrete Inputs (FC2) requests
+// ReadDiscreteInputsRTU combines Fields into RTU Read Discrete Inputs (FC2) requests
 func (b *Builder) ReadDiscreteInputsRTU() ([]BuilderRequest, error) {
-	return split(b.fields, packet.FunctionReadDiscreteInputs, ProtocolRTU)
+	return b.split(packet.FunctionReadDiscreteInputs, ProtocolRTU)
 }

--- a/splitter.go
+++ b/splitter.go
@@ -12,13 +12,26 @@ import (
 	"github.com/aldas/go-modbus-client/packet"
 )
 
-// split groups (by host:port+UnitID, "optimized" max amount of fields for max quantity) fields into packets
-func split(fields []Field, functionCode uint8, protocol ProtocolType) ([]BuilderRequest, error) {
+// Splitter groups Fields into Modbus requests
+type Splitter interface {
+	Split(fields Fields, functionCode uint8, protocol ProtocolType) ([]BuilderRequest, error)
+}
+
+// DefaultSplitter implements splitter logic that groups Fields by host:port+UnitID and splits them to BuilderRequest
+// "optimized" max amount of Fields for max number of fields as Modbus request size can contain
+type DefaultSplitter struct {
+	// ShouldSplitFunc is called for field addresses. If it returns true, the current address will be split into a
+	// new batch (request) and not added to the current batch.
+	ShouldSplitFunc func(batch SplitBatch, address uint16, size uint16) bool
+}
+
+// Split groups (by host:port+UnitID, "optimized" max amount of Fields for max quantity) Fields into packets
+func (s DefaultSplitter) Split(fields Fields, functionCode uint8, protocol ProtocolType) ([]BuilderRequest, error) {
 	connectionGroup, err := groupForSingleConnection(fields, functionCode, protocol)
 	if err != nil {
 		return nil, err
 	}
-	batches, err := batchToRequests(connectionGroup)
+	batches, err := splitGroupToBatches(connectionGroup, s.ShouldSplitFunc)
 	if err != nil {
 		return nil, err
 	}
@@ -97,7 +110,7 @@ func split(fields []Field, functionCode uint8, protocol ProtocolType) ([]Builder
 			Protocol:        b.Protocol,
 			RequestInterval: time.Duration(b.RequestInterval),
 
-			Fields: b.fields,
+			Fields: b.Fields,
 		})
 	}
 	if len(result) == 0 {
@@ -106,7 +119,7 @@ func split(fields []Field, functionCode uint8, protocol ProtocolType) ([]Builder
 	return result, nil
 }
 
-// groupForSingleConnection groups fields into groups what can be requested potentially by same request
+// groupForSingleConnection groups Fields into groups what can be requested potentially by same request
 // (same server + function + unit ID + protocol + interval)
 func groupForSingleConnection(fields []Field, functionCode uint8, protocol ProtocolType) ([]builderSlotGroup, error) {
 	//onlyCoils := functionCode == packet.FunctionReadCoils || functionCode == packet.FunctionReadDiscreteInputs
@@ -167,15 +180,15 @@ func groupForSingleConnection(fields []Field, functionCode uint8, protocol Proto
 	return result, nil
 }
 
-func batchToRequests(slotGroups []builderSlotGroup) ([]requestBatch, error) {
+func splitGroupToBatches(slotGroups []builderSlotGroup, shouldSplitFunc func(batch SplitBatch, address uint16, size uint16) bool) ([]SplitBatch, error) {
 	// Coils are always grouped to separate requests (fc1/fc2) from fields suitable for registers (fc3/fc4)
 	//
-	// NB: is batching/grouping algorithm is very naive. It just sorts fields by register and creates N number
-	// of requests of them by limiting quantity to MaxRegistersInReadResponse. It does not try to optimise long caps
-	// between fields
-	// assumes that UnitID is same for all fields within group
+	// NB: this batching/grouping algorithm is very naive. It just sorts fields by register and creates N number
+	// of requests of them by limiting the quantity to MaxRegistersInReadResponse. It does not try to optimize long caps
+	// between fields.
+	// assumes that UnitID is the same for all fields within a group
 
-	var result = make([]requestBatch, 0)
+	var result = make([]SplitBatch, 0)
 	for _, slotGroup := range slotGroups {
 		if len(slotGroup.slots) == 0 {
 			continue
@@ -197,7 +210,7 @@ func batchToRequests(slotGroups []builderSlotGroup) ([]requestBatch, error) {
 		})
 
 		firstAddress := slotGroup.slots[0].address
-		batch := requestBatch{
+		batch := SplitBatch{
 			ServerAddress:   slotGroup.group.serverAddress,
 			FunctionCode:    slotGroup.group.functionCode,
 			UnitID:          slotGroup.group.unitID,
@@ -216,10 +229,10 @@ func batchToRequests(slotGroups []builderSlotGroup) ([]requestBatch, error) {
 			if err != nil {
 				return nil, err
 			}
-			if isBiggerThanAddressLimit || isInvalidRangeOverlap {
+			if isBiggerThanAddressLimit || isInvalidRangeOverlap || (shouldSplitFunc != nil && shouldSplitFunc(batch, slotAddress, slot.size)) {
 				result = append(result, batch)
 
-				batch = requestBatch{
+				batch = SplitBatch{
 					ServerAddress:   slotGroup.group.serverAddress,
 					FunctionCode:    slotGroup.group.functionCode,
 					UnitID:          slotGroup.group.unitID,
@@ -236,7 +249,7 @@ func batchToRequests(slotGroups []builderSlotGroup) ([]requestBatch, error) {
 				batch.Quantity = addressDiff
 			}
 
-			batch.fields = append(batch.fields, slot.fields...)
+			batch.Fields = append(batch.Fields, slot.fields...)
 		}
 		result = append(result, batch)
 	}
@@ -297,7 +310,8 @@ func (g *builderSlotGroup) AddField(f Field) {
 	g.slots[i] = slot
 }
 
-type requestBatch struct {
+// SplitBatch represents a group of fields that are requested to the same Modbus request
+type SplitBatch struct {
 	ServerAddress string
 	FunctionCode  uint8
 	UnitID        uint8
@@ -309,7 +323,7 @@ type requestBatch struct {
 	IsForCoils      bool
 	RequestInterval Duration
 
-	fields Fields
+	Fields Fields
 }
 
 // invalidAddress is (register/coil) range in between modbus server should not be requested
@@ -346,7 +360,7 @@ func addressToSplitterConfig(address string) (splitterConfig, error) {
 	}
 	url, err := url.Parse(address)
 	if err != nil {
-		return splitterConfig{}, fmt.Errorf("failed to parse server adddres for invalid range: %q, err: %w", address, err)
+		return splitterConfig{}, fmt.Errorf("failed to parse server address for invalid range: %q, err: %w", address, err)
 	}
 	invalid, err := addressToInvalidRange(url)
 	if err != nil {

--- a/splitter_test.go
+++ b/splitter_test.go
@@ -21,7 +21,7 @@ func TestSplit_validationError(t *testing.T) {
 		},
 	}
 
-	batched, err := split(given, 3, ProtocolTCP)
+	batched, err := DefaultSplitter{}.Split(given, 3, ProtocolTCP)
 	assert.EqualError(t, err, "field server address can not be empty")
 	assert.Nil(t, batched)
 }
@@ -31,7 +31,7 @@ func TestSplit_single(t *testing.T) {
 		{ServerAddress: ":502", UnitID: 0, Address: 1, Type: FieldTypeInt8},
 	}
 
-	batched, err := split(given, 3, ProtocolTCP)
+	batched, err := DefaultSplitter{}.Split(given, 3, ProtocolTCP)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 1)
 
@@ -67,7 +67,7 @@ func TestSplit_quantity(t *testing.T) {
 			expectQuantity:     4,
 		},
 		{
-			name: "ok, multiple fields",
+			name: "ok, multiple Fields",
 			givenFields: []Field{
 				{ServerAddress: ":502", UnitID: 0, Address: 10, Type: FieldTypeInt8},
 				{ServerAddress: ":502", UnitID: 0, Address: 74, Type: FieldTypeUint32},
@@ -76,7 +76,7 @@ func TestSplit_quantity(t *testing.T) {
 			expectQuantity:     66,
 		},
 		{
-			name: "ok, multiple fields int8",
+			name: "ok, multiple Fields int8",
 			givenFields: []Field{
 				{ServerAddress: ":502", UnitID: 0, Address: 10, Type: FieldTypeInt8},
 				{ServerAddress: ":502", UnitID: 0, Address: 75, Type: FieldTypeInt8},
@@ -85,7 +85,7 @@ func TestSplit_quantity(t *testing.T) {
 			expectQuantity:     66,
 		},
 		{
-			name: "ok, multiple fields int64",
+			name: "ok, multiple Fields int64",
 			givenFields: []Field{
 				{ServerAddress: ":502", UnitID: 0, Address: 0, Type: FieldTypeInt8},
 				{ServerAddress: ":502", UnitID: 0, Address: 1, Type: FieldTypeFloat64},
@@ -97,7 +97,7 @@ func TestSplit_quantity(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 
-			batched, err := split(tc.givenFields, 3, ProtocolTCP)
+			batched, err := DefaultSplitter{}.Split(tc.givenFields, 3, ProtocolTCP)
 			if assert.NoError(t, err) {
 				assert.Len(t, batched, 1)
 				req := batched[0].Request.(*packet.ReadHoldingRegistersRequestTCP)
@@ -132,7 +132,7 @@ func TestSplit_many(t *testing.T) {
 		},
 	}
 
-	batched, err := split(given, 3, ProtocolTCP)
+	batched, err := DefaultSplitter{}.Split(given, 3, ProtocolTCP)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 1)
 
@@ -168,7 +168,7 @@ func TestSplit_to2RegisterBatches(t *testing.T) {
 		},
 	}
 
-	batched, err := split(given, packet.FunctionReadHoldingRegisters, ProtocolTCP)
+	batched, err := DefaultSplitter{}.Split(given, packet.FunctionReadHoldingRegisters, ProtocolTCP)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 2)
 
@@ -214,7 +214,7 @@ func TestSplit_to2CoilsBatches(t *testing.T) {
 		},
 	}
 
-	batched, err := split(given, 1, ProtocolTCP)
+	batched, err := DefaultSplitter{}.Split(given, 1, ProtocolTCP)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 2)
 
@@ -247,7 +247,7 @@ func TestSplit_Serialto2CoilsBatches(t *testing.T) {
 		},
 	}
 
-	batched, err := split(given, 3, ProtocolRTU)
+	batched, err := DefaultSplitter{}.Split(given, 3, ProtocolRTU)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 2)
 }
@@ -268,7 +268,7 @@ func TestSplit_maxQuantityPerRequest(t *testing.T) {
 		},
 	}
 
-	batched, err := split(given, 3, ProtocolRTU)
+	batched, err := DefaultSplitter{}.Split(given, 3, ProtocolRTU)
 	assert.NoError(t, err)
 	assert.Len(t, batched, 2)
 }
@@ -412,7 +412,7 @@ func TestAddressToSplitterConfig(t *testing.T) {
 		{
 			name:        "ok, random port url is problematic",
 			whenAddress: "[::]:45310?invalid_addr=10",
-			expectErr:   `failed to parse server adddres for invalid range: "[::]:45310?invalid_addr=10", err: parse "[::]:45310?invalid_addr=10": first path segment in URL cannot contain colon`,
+			expectErr:   `failed to parse server address for invalid range: "[::]:45310?invalid_addr=10", err: parse "[::]:45310?invalid_addr=10": first path segment in URL cannot contain colon`,
 		},
 		{
 			name:        "ok, empty random port url",
@@ -515,10 +515,11 @@ func TestAddressToInvalidRange(t *testing.T) {
 
 func TestBatchToRequests(t *testing.T) {
 	var testCases = []struct {
-		name      string
-		when      []builderSlotGroup
-		expect    []requestBatch
-		expectErr string
+		name                string
+		when                []builderSlotGroup
+		whenShouldSplitFunc func(batch SplitBatch, address uint16, size uint16) bool
+		expect              []SplitBatch
+		expectErr           string
 	}{
 		{
 			name: "ok, split at invalid address",
@@ -537,7 +538,7 @@ func TestBatchToRequests(t *testing.T) {
 					},
 				},
 			},
-			expect: []requestBatch{
+			expect: []SplitBatch{
 				{
 					ServerAddress:   "/dev/ttyS0?invalid_addr=15-20&invalid_addr=5",
 					FunctionCode:    3,
@@ -546,7 +547,7 @@ func TestBatchToRequests(t *testing.T) {
 					StartAddress:    2,
 					Quantity:        3,
 					RequestInterval: 0,
-					fields:          nil,
+					Fields:          nil,
 				},
 				{
 					ServerAddress:   "/dev/ttyS0?invalid_addr=15-20&invalid_addr=5",
@@ -556,7 +557,51 @@ func TestBatchToRequests(t *testing.T) {
 					StartAddress:    10,
 					Quantity:        4,
 					RequestInterval: 0,
-					fields:          nil,
+					Fields:          nil,
+				},
+			},
+		},
+		{
+			name: "ok, custom shouldSplitFunc",
+			whenShouldSplitFunc: func(batch SplitBatch, address uint16, size uint16) bool {
+				// split to new request when addresses are not consecutive
+				return address-batch.StartAddress > 1
+			},
+			when: []builderSlotGroup{
+				{
+					group: groupID{
+						serverAddress: "/dev/ttyS0",
+						functionCode:  3,
+						unitID:        1,
+						protocol:      ProtocolRTU,
+					},
+					slots: builderSlots{
+						{address: 2, size: 1, fields: nil},  // 2
+						{address: 3, size: 2, fields: nil},  // 3,4
+						{address: 10, size: 4, fields: nil}, // 10,11,12,13
+					},
+				},
+			},
+			expect: []SplitBatch{
+				{
+					ServerAddress:   "/dev/ttyS0",
+					FunctionCode:    3,
+					UnitID:          1,
+					Protocol:        ProtocolRTU,
+					StartAddress:    2,
+					Quantity:        3,
+					RequestInterval: 0,
+					Fields:          nil,
+				},
+				{
+					ServerAddress:   "/dev/ttyS0",
+					FunctionCode:    3,
+					UnitID:          1,
+					Protocol:        ProtocolRTU,
+					StartAddress:    10,
+					Quantity:        4,
+					RequestInterval: 0,
+					Fields:          nil,
 				},
 			},
 		},
@@ -583,7 +628,7 @@ func TestBatchToRequests(t *testing.T) {
 	}
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			result, err := batchToRequests(tc.when)
+			result, err := splitGroupToBatches(tc.when, tc.whenShouldSplitFunc)
 
 			assert.Equal(t, tc.expect, result)
 			if tc.expectErr != "" {


### PR DESCRIPTION
add Splitter interface and default implementation


Example:
```go
	b := modbus.NewRequestBuilderWithConfig(modbus.BuilderDefaults{
		ServerAddress: "tcp://172.25.28.29:8899",
		FunctionCode:  packet.FunctionReadHoldingRegisters,
		UnitID:        1,
		Protocol:      modbus.ProtocolTCP,
		Interval:      modbus.Duration(5 * time.Second),
		Splitter: modbus.DefaultSplitter{
			ShouldSplitFunc: func(batch modbus.SplitBatch, address uint16, size uint16) bool {
				// split to new request when addresses are not consecutive
				return int(address) - int(batch.StartAddress + batch.Quantity - 1) > 1
			},
		},
	})
```